### PR TITLE
Feature/register card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # 📋 Changelog
 
+## [v1.1.6] - 2025-08-12
+
+### ✨ Nuevas funcionalidades
+
+- **Actualización de datos de usuario autenticado**:
+  - Se implementó el endpoint **`PUT /api/v1/users`** para que el usuario autenticado pueda actualizar su información personal.
+  - Soporte para modificar datos primitivos como teléfono, dirección, descripción y foto de perfil.
+  - Manejo seguro de datos relacionados (por ejemplo, información de restaurante o administrador) sin afectar otros registros asociados.
+  - Validaciones estrictas en el DTO para garantizar integridad y formato correcto de la información recibida.
+  - Respuestas claras y consistentes ante actualizaciones exitosas o fallidas.
+
+#### 📌 Campos que se pueden actualizar
+
+- **Campos primitivos**:
+  - `phone` → Número de teléfono.
+  - `district` → Distrito de residencia.
+  - `province` → Provincia de residencia.
+  - `description` → Descripción o bio del usuario (opcional).
+  - `profilePicture` → URL o base64 de la foto de perfil (opcional).
+
+- **Datos relacionados** (opcional, actualizando solo lo enviado):
+  - `restaurant` → Datos del restaurante asociado (ej. nombre, dirección, horarios).
+  - `admin` → Datos del perfil administrador (ej. username).
+
+### 🛠️ Cambios técnicos
+
+- Implementación de lógica para diferenciar campos primitivos de relaciones antes de persistir cambios.
+- Actualización de Swagger para documentar el nuevo endpoint con ejemplos de peticiones y respuestas.
+- Refactor de validaciones para optimizar la verificación de datos opcionales.
+
 ## [v1.1.5] - 2025-08-11
 
 ### ✨ Nuevas funcionalidades

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,28 @@
 # 📋 Changelog
 
-## [v1.3.0] - 2025-08-11
+## [v1.1.5] - 2025-08-11
+
+### ✨ Nuevas funcionalidades
+
+- **Función para eliminar usuarios por ID**:
+  - Se implementó el endpoint **`DELETE /api/v1/users/{id}`** para eliminar un usuario específico mediante su identificador.
+  - Verificación previa para confirmar que el usuario exista antes de proceder con la eliminación.
+  - Respuesta clara en caso de éxito o cuando el usuario no se encuentra.
+  - Manejo adecuado de errores con mensajes descriptivos para facilitar el debugging.
+  - Soporte para soft delete (eliminación lógica) o eliminación física, según configuración.
+
+### 🛠️ Cambios técnicos
+
+- Se añadió método `deleteUserById` en el servicio de usuarios.
+- Actualización de DTOs y validaciones para manejar correctamente el parámetro `id`.
+- Documentación Swagger actualizada para el nuevo endpoint con ejemplos y posibles respuestas.
+
+## [v1.1.4] - 2025-08-11
 
 ### ✨ Nuevas funcionalidades
 
 - **Listado de usuarios con paginación, filtros y carga dinámica de relaciones**:
-  - Se implementó el endpoint **`POST /api/v1/users/search?page={page}&limit={limit}`** para obtener usuarios con soporte de paginación mediante _query params_.
+  - Se implementó el endpoint **`POST /api/v1/users?page={page}&limit={limit}`** para obtener usuarios con soporte de paginación mediante _query params_.
   - **Selección de campos**: Permite indicar en `select` qué columnas devolver de la entidad principal.
   - **Relaciones dinámicas**: Soporta incluir relaciones simples (`['restaurant', 'admin', 'consumer]`) o anidadas (`{ restaurant: ['id', 'name'], admin: ['isDeleted'] }`).
   - **Filtros avanzados**: En el cuerpo (`where`) se pueden definir condiciones con operadores (`eq`, `like`, `gte`, `lte`) o valores exactos.
@@ -20,7 +37,7 @@
 
 ### 📌 Ruta para buscar usuarios
 
-**`GET /api/v1/users/search?page={page}&limit={limit}`**
+**`GET /api/v1/userspage={page}&limit={limit}`**
 
 ## [v1.2.0] - 2025-08-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # 📋 Changelog
 
+## [v1.1.7] - 2025-08-16
+
+### ✨ Nuevas funcionalidades
+
+- **Creación de cartas asociadas a un restaurante**:
+  - Se implementó el endpoint **`POST /api/v1/restaurants/{restaurantId}/cards`** para registrar nuevas cartas vinculadas directamente a un restaurante específico mediante **Path Param**.
+  - La relación asegura que cada carta quede correctamente asociada al restaurante correspondiente en base al `restaurantId` proporcionado.
+  - Validaciones estrictas para verificar la existencia del restaurante antes de permitir la creación de la carta.
+  - Respuestas claras en caso de éxito o errores de validación (ej. restaurante inexistente).
+
+#### 📌 Datos requeridos en la creación de la carta
+
+- **Path Param**:
+  - `restaurantId` → Identificador único del restaurante.
+
+- **Body**:
+  - `title` → Título o nombre de la carta.
+  - `description` → Breve descripción de la carta.
+  - `isActive` → Estado de la carta (activa o inactiva).
+
+### 🛠️ Cambios técnicos
+
+- Creación de la lógica de asociación entre `Card` y `Restaurant` mediante `restaurantId`.
+- Actualización de repositorios y casos de uso para soportar la creación de cartas por relación.
+- Documentación en Swagger del nuevo endpoint con ejemplos de requests y responses.
+
 ## [v1.1.6] - 2025-08-12
 
 ### ✨ Nuevas funcionalidades

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # 📋 Changelog
 
+## [v1.3.0] - 2025-08-11
+
+### ✨ Nuevas funcionalidades
+
+- **Listado de usuarios con paginación, filtros y carga dinámica de relaciones**:
+  - Se implementó el endpoint **`POST /api/v1/users/search?page={page}&limit={limit}`** para obtener usuarios con soporte de paginación mediante _query params_.
+  - **Selección de campos**: Permite indicar en `select` qué columnas devolver de la entidad principal.
+  - **Relaciones dinámicas**: Soporta incluir relaciones simples (`['restaurant', 'admin', 'consumer]`) o anidadas (`{ restaurant: ['id', 'name'], admin: ['isDeleted'] }`).
+  - **Filtros avanzados**: En el cuerpo (`where`) se pueden definir condiciones con operadores (`eq`, `like`, `gte`, `lte`) o valores exactos.
+  - **Ordenamiento**: Permite ordenar ascendente o descendente por uno o varios campos mediante `order`.
+  - Optimiza la consulta devolviendo únicamente la información necesaria para el cliente.
+
+### 🛠️ Cambios técnicos
+
+- Se creó el DTO **`SearchUserDto`** con validaciones para `select`, `relations`, `where` y `order`.
+- Se añadió lógica en el servicio para interpretar filtros y relaciones anidadas.
+- Se actualizó la documentación **Swagger** con ejemplos para cada campo y estructura soportada.
+
+### 📌 Ruta para buscar usuarios
+
+**`GET /api/v1/users/search?page={page}&limit={limit}`**
+
 ## [v1.2.0] - 2025-08-07
 
 ### ✨ Nuevas funcionalidades

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -10,6 +10,7 @@ import { LoggerMiddleware } from 'src/common/middleware/logger.middleware';
 import { AppController } from 'src/interfaces/controllers/app/app.controller';
 import { AuthenticationModule } from './modules/authentication/authentication.module';
 import { UserModule } from './modules/user/user.module';
+import { CardModule } from './modules/card/card.module';
 
 // Environment file paths
 const nodeEnv = process.env.NODE_ENV || 'development';
@@ -52,7 +53,8 @@ const envTemplatePath = join(process.cwd(), 'config', 'environments', `${nodeEnv
       inject: [ConfigService]
     }),
     AuthenticationModule,
-    UserModule
+    UserModule,
+    CardModule
   ],
   controllers: [AppController],
   providers: [

--- a/src/app/modules/card/card.module.ts
+++ b/src/app/modules/card/card.module.ts
@@ -1,0 +1,23 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { CardEntity } from '../../../infrastructure/database/entities/card/card.entity';
+import { RestaurantEntity } from '../../../infrastructure/database/entities/restaurant/restaurant.entity';
+import { CreateCardUseCase } from '../../../core/use-cases/card/create-card.use-case';
+import { TypeOrmCardRepository } from '../../../infrastructure/database/entities/card/repository/typeorm-card.repository';
+import { CardController } from '../../../interfaces/controllers/card/restaurant.controller';
+
+const useCases = [CreateCardUseCase];
+
+@Module({
+  imports: [TypeOrmModule.forFeature([CardEntity, RestaurantEntity])],
+  providers: [
+    TypeOrmCardRepository,
+    ...useCases.map((useCase) => ({
+      provide: useCase,
+      useFactory: (cardRepo: TypeOrmCardRepository) => new useCase(cardRepo),
+      inject: [TypeOrmCardRepository]
+    }))
+  ],
+  controllers: [CardController]
+})
+export class CardModule {}

--- a/src/app/modules/user/user.module.ts
+++ b/src/app/modules/user/user.module.ts
@@ -14,8 +14,9 @@ import { UserCreateProfileUseCase } from '../../../core/use-cases/user/user-crea
 import { RoleGuard } from '../../../common/guards/roles.guard';
 import { GetAllUsersUseCase } from '../../../core/use-cases/user/get-all-users.use-case';
 import { DeleteUserUseCase } from '../../../core/use-cases/user/delete-user.use-case';
+import { UpdateUserProfileUseCase } from '../../../core/use-cases/user/update-user-profile.use-case';
 
-const useCases = [UserCreateProfileUseCase, GetAllUsersUseCase, DeleteUserUseCase];
+const useCases = [UserCreateProfileUseCase, GetAllUsersUseCase, DeleteUserUseCase, UpdateUserProfileUseCase];
 
 @Module({
   imports: [

--- a/src/app/modules/user/user.module.ts
+++ b/src/app/modules/user/user.module.ts
@@ -13,8 +13,9 @@ import { UserController } from '../../../interfaces/controllers/user/user.contro
 import { UserCreateProfileUseCase } from '../../../core/use-cases/user/user-create-profile.use-case';
 import { RoleGuard } from '../../../common/guards/roles.guard';
 import { GetAllUsersUseCase } from '../../../core/use-cases/user/get-all-users.use-case';
+import { DeleteUserUseCase } from '../../../core/use-cases/user/delete-user.use-case';
 
-const useCases = [UserCreateProfileUseCase, GetAllUsersUseCase];
+const useCases = [UserCreateProfileUseCase, GetAllUsersUseCase, DeleteUserUseCase];
 
 @Module({
   imports: [

--- a/src/app/modules/user/user.module.ts
+++ b/src/app/modules/user/user.module.ts
@@ -11,8 +11,10 @@ import { ConsumerEntity } from '../../../infrastructure/database/entities/consum
 import { TypeOrmUserProfile } from '../../../infrastructure/database/entities/user/repository/typeorm-user-profile.repository';
 import { UserController } from '../../../interfaces/controllers/user/user.controller';
 import { UserCreateProfileUseCase } from '../../../core/use-cases/user/user-create-profile.use-case';
+import { RoleGuard } from '../../../common/guards/roles.guard';
+import { GetAllUsersUseCase } from '../../../core/use-cases/user/get-all-users.use-case';
 
-const useCases = [UserCreateProfileUseCase];
+const useCases = [UserCreateProfileUseCase, GetAllUsersUseCase];
 
 @Module({
   imports: [
@@ -23,6 +25,7 @@ const useCases = [UserCreateProfileUseCase];
   providers: [
     JwtStrategy,
     TypeOrmUserProfile,
+    RoleGuard,
     ...useCases.map((useCase) => ({
       provide: useCase,
       useFactory: (userRepo: TypeOrmUserProfile) => new useCase(userRepo),

--- a/src/common/decorators/role/role.decorator.ts
+++ b/src/common/decorators/role/role.decorator.ts
@@ -1,0 +1,6 @@
+import { SetMetadata } from '@nestjs/common';
+import { Role } from '../../enums/role/role.enum';
+
+export const ROLES_KEY = 'roles';
+
+export const Roles = (...roles: Role[]) => SetMetadata(ROLES_KEY, roles);

--- a/src/common/enums/role/role.enum.ts
+++ b/src/common/enums/role/role.enum.ts
@@ -1,0 +1,5 @@
+export enum Role {
+  ADMIN = 'admin',
+  CONSUMER = 'consumer',
+  RESTAURANT = 'restaurant'
+}

--- a/src/common/guards/__test__/roles.guard.spec.ts
+++ b/src/common/guards/__test__/roles.guard.spec.ts
@@ -1,0 +1,79 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Reflector } from '@nestjs/core';
+import { ForbiddenException, UnauthorizedException } from '@nestjs/common';
+import { RoleGuard } from '../roles.guard';
+import { UserServiceCommon } from '../../user-common/user.service';
+import { Role } from '../../enums/role/role.enum';
+
+describe('RoleGuard', () => {
+  let guard: RoleGuard;
+  let userService: jest.Mocked<UserServiceCommon>;
+  let reflector: jest.Mocked<Reflector>;
+
+  const mockContext = (roles: Role[] | null, userSub: string = 'user123') =>
+    ({
+      getHandler: jest.fn(),
+      getClass: jest.fn(),
+      switchToHttp: () => ({
+        getRequest: () => ({ user: { sub: userSub } })
+      })
+    }) as any;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RoleGuard,
+        { provide: UserServiceCommon, useValue: { findRoleByUserSub: jest.fn() } },
+        { provide: Reflector, useValue: { getAllAndOverride: jest.fn() } }
+      ]
+    }).compile();
+
+    guard = module.get<RoleGuard>(RoleGuard);
+    userService = module.get(UserServiceCommon);
+    reflector = module.get(Reflector);
+  });
+
+  describe('canActivate', () => {
+    it('should return true when no roles required', async () => {
+      reflector.getAllAndOverride.mockReturnValue(null);
+      const result = await guard.canActivate(mockContext(null));
+      expect(result).toBe(true);
+    });
+
+    it('should return true when user has required role', async () => {
+      reflector.getAllAndOverride.mockReturnValue([Role.ADMIN]);
+      userService.findRoleByUserSub.mockResolvedValue(Role.ADMIN);
+
+      const result = await guard.canActivate(mockContext([Role.ADMIN]));
+
+      expect(result).toBe(true);
+      expect(userService.findRoleByUserSub).toHaveBeenCalledWith('user123');
+    });
+
+    it('should throw UnauthorizedException when user not found', async () => {
+      reflector.getAllAndOverride.mockReturnValue([Role.ADMIN]);
+      userService.findRoleByUserSub.mockResolvedValue(null);
+
+      await expect(guard.canActivate(mockContext([Role.ADMIN]))).rejects.toThrow(
+        new UnauthorizedException('Usuario no encontrado')
+      );
+    });
+
+    it('should throw ForbiddenException when user lacks required role', async () => {
+      reflector.getAllAndOverride.mockReturnValue([Role.ADMIN]);
+      userService.findRoleByUserSub.mockResolvedValue(Role.CONSUMER);
+
+      await expect(guard.canActivate(mockContext([Role.ADMIN]))).rejects.toThrow(
+        new ForbiddenException('No tienes el rol requerido')
+      );
+    });
+
+    it('should work with multiple required roles', async () => {
+      reflector.getAllAndOverride.mockReturnValue([Role.ADMIN, Role.RESTAURANT]);
+      userService.findRoleByUserSub.mockResolvedValue(Role.RESTAURANT);
+
+      const result = await guard.canActivate(mockContext([Role.ADMIN, Role.RESTAURANT]));
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/src/common/guards/roles.guard.ts
+++ b/src/common/guards/roles.guard.ts
@@ -1,0 +1,38 @@
+import { CanActivate, ExecutionContext, ForbiddenException, Injectable, UnauthorizedException } from '@nestjs/common';
+import { UserServiceCommon } from '../user-common/user.service';
+import { Reflector } from '@nestjs/core';
+import { Role } from '../enums/role/role.enum';
+import { ROLES_KEY } from '../decorators/role/role.decorator';
+import { Request } from 'express';
+
+@Injectable()
+export class RoleGuard implements CanActivate {
+  constructor(
+    private readonly userService: UserServiceCommon,
+    private readonly reflector: Reflector
+  ) {}
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const requiredRoles = this.reflector.getAllAndOverride<Role[]>(ROLES_KEY, [
+      context.getHandler(),
+      context.getClass()
+    ]);
+
+    if (!requiredRoles || requiredRoles.length === 0) {
+      return true;
+    }
+
+    const request = context.switchToHttp().getRequest<Request>();
+    const userPayload = request.user as { sub: string };
+
+    const roleUser = await this.userService.findRoleByUserSub(userPayload.sub);
+
+    if (!roleUser) {
+      throw new UnauthorizedException('Usuario no encontrado');
+    }
+
+    if (!requiredRoles.includes(roleUser as Role)) {
+      throw new ForbiddenException('No tienes el rol requerido');
+    }
+    return true;
+  }
+}

--- a/src/common/user-common/__test__/user.service.spec.ts
+++ b/src/common/user-common/__test__/user.service.spec.ts
@@ -28,22 +28,45 @@ describe('UserServiceCommon', () => {
     jest.clearAllMocks();
   });
 
-  it('should return true if user exists by sub', async () => {
-    const fakeUser = { id: 1, sub: 'abc123' } as UserEntity;
-    mockUserRepository.findOne.mockResolvedValue(fakeUser);
+  describe('userExistBySub', () => {
+    it('should return true if user exists by sub', async () => {
+      const fakeUser = { id: 1, sub: 'abc123' } as UserEntity;
+      mockUserRepository.findOne.mockResolvedValue(fakeUser);
 
-    const result = await service.userExistBySub('abc123');
+      const result = await service.userExistBySub('abc123');
 
-    expect(result).toBe(true);
-    expect(mockUserRepository.findOne).toHaveBeenCalledWith({ where: { sub: 'abc123' } });
+      expect(result).toBe(true);
+      expect(mockUserRepository.findOne).toHaveBeenCalledWith({ where: { sub: 'abc123' } });
+    });
+
+    it('should return false if user does not exist by sub', async () => {
+      mockUserRepository.findOne.mockResolvedValue(null);
+
+      const result = await service.userExistBySub('nonexistent');
+
+      expect(result).toBe(false);
+      expect(mockUserRepository.findOne).toHaveBeenCalledWith({ where: { sub: 'nonexistent' } });
+    });
   });
 
-  it('should return false if user does not exist by sub', async () => {
-    mockUserRepository.findOne.mockResolvedValue(null);
+  describe('findRoleByUserSub', () => {
+    it('should return role if user exists', async () => {
+      const fakeUser = { id: 1, sub: 'abc123', role: 'admin' } as UserEntity;
+      mockUserRepository.findOne.mockResolvedValue(fakeUser);
 
-    const result = await service.userExistBySub('nonexistent');
+      const result = await service.findRoleByUserSub('abc123');
 
-    expect(result).toBe(false);
-    expect(mockUserRepository.findOne).toHaveBeenCalledWith({ where: { sub: 'nonexistent' } });
+      expect(result).toBe('admin');
+      expect(mockUserRepository.findOne).toHaveBeenCalledWith({ where: { sub: 'abc123' } });
+    });
+
+    it('should return null if user does not exist', async () => {
+      mockUserRepository.findOne.mockResolvedValue(null);
+
+      const result = await service.findRoleByUserSub('nonexistent');
+
+      expect(result).toBeNull();
+      expect(mockUserRepository.findOne).toHaveBeenCalledWith({ where: { sub: 'nonexistent' } });
+    });
   });
 });

--- a/src/common/user-common/user.service.ts
+++ b/src/common/user-common/user.service.ts
@@ -13,4 +13,12 @@ export class UserServiceCommon {
     const user = await this.userRepository.findOne({ where: { sub: sub } });
     return !!user;
   }
+
+  async findRoleByUserSub(sub: string): Promise<string | null> {
+    const user = await this.userRepository.findOne({ where: { sub } });
+
+    if (!user) return null;
+
+    return user.role;
+  }
 }

--- a/src/common/utils/pagination/__test__/pagination-with-filters.spec.ts
+++ b/src/common/utils/pagination/__test__/pagination-with-filters.spec.ts
@@ -1,0 +1,114 @@
+import { Repository, SelectQueryBuilder } from 'typeorm';
+import { paginateWithFilters } from '../pagination-with-filters';
+import { SearchParams } from '../../../../core/domain/dto/search/search-param';
+
+function createQueryBuilderMock<T>() {
+  const qb: Partial<SelectQueryBuilder<T>> = {
+    select: jest.fn().mockReturnThis(),
+    addSelect: jest.fn().mockReturnThis(),
+    leftJoin: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    addOrderBy: jest.fn().mockReturnThis(),
+    skip: jest.fn().mockReturnThis(),
+    take: jest.fn().mockReturnThis(),
+    getManyAndCount: jest.fn().mockResolvedValue([[{ id: 1, name: 'Test' }], 1])
+  };
+  return qb as SelectQueryBuilder<T>;
+}
+
+describe('paginateWithFilters', () => {
+  let repositoryMock: Partial<Repository<any>>;
+  let qbMock: SelectQueryBuilder<any>;
+
+  beforeEach(() => {
+    qbMock = createQueryBuilderMock();
+    repositoryMock = {
+      metadata: { tableName: 'users' } as any,
+      createQueryBuilder: jest.fn().mockReturnValue(qbMock)
+    };
+  });
+
+  it('debería paginar con select, where like y order básico', async () => {
+    const searchParams: SearchParams = {
+      page: 1,
+      limit: 10,
+      select: ['id', 'name'],
+      where: { name: { op: 'like', value: 'Test' } },
+      order: { id: 'ASC' }
+    };
+
+    const result = await paginateWithFilters(repositoryMock as Repository<any>, searchParams);
+
+    expect(repositoryMock.createQueryBuilder).toHaveBeenCalledWith('users');
+    expect(qbMock.select).toHaveBeenCalledWith(['users.id', 'users.name']);
+    expect(qbMock.andWhere).toHaveBeenCalledWith('users.name LIKE :name', { name: '%Test%' });
+    expect(qbMock.addOrderBy).toHaveBeenCalledWith('users.id', 'ASC');
+    expect(result.paginationData.total).toBe(1);
+  });
+
+  it('debería soportar relations con campos seleccionados', async () => {
+    const searchParams: SearchParams = {
+      page: 1,
+      limit: 5,
+      relations: { profile: ['age', 'country'] }
+    };
+
+    await paginateWithFilters(repositoryMock as Repository<any>, searchParams);
+
+    expect(qbMock.leftJoin).toHaveBeenCalledWith('users.profile', 'profile');
+    expect(qbMock.addSelect).toHaveBeenCalledWith('profile.age');
+    expect(qbMock.addSelect).toHaveBeenCalledWith('profile.country');
+  });
+
+  it('debería soportar where simple sin operador', async () => {
+    const searchParams: SearchParams = {
+      page: 1,
+      limit: 5,
+      where: { isActive: true }
+    };
+
+    await paginateWithFilters(repositoryMock as Repository<any>, searchParams);
+
+    expect(qbMock.andWhere).toHaveBeenCalledWith('users.isActive = :isActive', { isActive: true });
+  });
+
+  it('debería soportar where anidado con operador gte', async () => {
+    const searchParams = {
+      page: 1,
+      limit: 5,
+      where: {
+        profile: {
+          age: { op: 'gte', value: 18 }
+        }
+      }
+    } as unknown as SearchParams;
+
+    await paginateWithFilters(repositoryMock as Repository<any>, searchParams);
+
+    expect(qbMock.andWhere).toHaveBeenCalledWith('profile.age >= :profile_age', { profile_age: 18 });
+  });
+
+  it('debería soportar order en relación', async () => {
+    const searchParams: SearchParams = {
+      page: 1,
+      limit: 5,
+      order: { 'profile.age': 'DESC' }
+    };
+
+    await paginateWithFilters(repositoryMock as Repository<any>, searchParams);
+
+    expect(qbMock.addOrderBy).toHaveBeenCalledWith('profile.age', 'DESC');
+  });
+
+  it('debería paginar sin select ni order ni where', async () => {
+    const searchParams: SearchParams = {
+      page: 2,
+      limit: 1
+    };
+
+    await paginateWithFilters(repositoryMock as Repository<any>, searchParams);
+
+    expect(qbMock.skip).toHaveBeenCalledWith(1);
+    expect(qbMock.take).toHaveBeenCalledWith(1);
+  });
+});

--- a/src/common/utils/pagination/__test__/pagination.spec.ts
+++ b/src/common/utils/pagination/__test__/pagination.spec.ts
@@ -1,0 +1,73 @@
+// paginate.spec.ts
+import { Repository } from 'typeorm';
+import { paginate } from '../pagination';
+
+describe('paginate', () => {
+  let repo: jest.Mocked<Repository<any>>;
+
+  beforeEach(() => {
+    repo = {
+      findAndCount: jest.fn()
+    } as unknown as jest.Mocked<Repository<any>>;
+  });
+
+  it('debería paginar correctamente con valores por defecto', async () => {
+    const mockData = [{ id: 1 }, { id: 2 }];
+    repo.findAndCount.mockResolvedValue([mockData, 15]);
+
+    const result = await paginate(repo, 1, 10);
+
+    expect(repo.findAndCount).toHaveBeenCalledWith({
+      skip: 0,
+      take: 10
+    });
+    expect(result).toEqual({
+      data: mockData,
+      paginationData: {
+        total: 15,
+        currentPage: 1,
+        lastPage: 2,
+        nextPage: 2,
+        perPage: 10
+      }
+    });
+  });
+
+  it('debería calcular bien el skip y nextPage', async () => {
+    const mockData = [{ id: 3 }, { id: 4 }];
+    repo.findAndCount.mockResolvedValue([mockData, 25]);
+
+    const result = await paginate(repo, 2, 5);
+
+    expect(repo.findAndCount).toHaveBeenCalledWith({
+      skip: 5,
+      take: 5
+    });
+    expect(result.paginationData.currentPage).toBe(2);
+    expect(result.paginationData.nextPage).toBe(3);
+  });
+
+  it('debería devolver nextPage como null si es la última página', async () => {
+    const mockData = [{ id: 5 }];
+    repo.findAndCount.mockResolvedValue([mockData, 6]);
+
+    const result = await paginate(repo, 2, 3);
+
+    expect(result.paginationData.lastPage).toBe(2);
+    expect(result.paginationData.nextPage).toBeNull();
+  });
+
+  it('debería aceptar opciones adicionales de TypeORM', async () => {
+    const mockData = [{ id: 1 }];
+    repo.findAndCount.mockResolvedValue([mockData, 1]);
+
+    const options = { where: { name: 'Test' }, order: { id: 'DESC' } };
+    await paginate(repo, 1, 10, options);
+
+    expect(repo.findAndCount).toHaveBeenCalledWith({
+      skip: 0,
+      take: 10,
+      ...options
+    });
+  });
+});

--- a/src/common/utils/pagination/pagination-with-filters.ts
+++ b/src/common/utils/pagination/pagination-with-filters.ts
@@ -106,7 +106,6 @@ export async function paginateWithFilters<T>(repository: Repository<T>, searchPa
 
   const lastPage = Math.ceil(total / limit);
   const nextPage = page < lastPage ? page + 1 : null;
-  console.log(data);
   return {
     data,
     paginationData: {

--- a/src/common/utils/pagination/pagination-with-filters.ts
+++ b/src/common/utils/pagination/pagination-with-filters.ts
@@ -13,16 +13,24 @@ export async function paginateWithFilters<T>(repository: Repository<T>, searchPa
   }
 
   // RELATIONS con campos seleccionados
-  if (relations && typeof relations === 'object') {
-    Object.entries(relations).forEach(([relation, fields]) => {
-      const relationAlias = `${relation}`;
-      qb.leftJoin(`${alias}.${relation}`, relationAlias);
-      if (Array.isArray(fields) && fields.length) {
-        fields.forEach((field) => {
-          qb.addSelect(`${relationAlias}.${field}`);
-        });
-      }
-    });
+  if (relations) {
+    if (Array.isArray(relations)) {
+      // Array simple de relaciones
+      relations.forEach((relation) => {
+        qb.leftJoinAndSelect(`${alias}.${relation}`, relation);
+      });
+    } else if (typeof relations === 'object') {
+      // Objeto con relaciones y campos seleccionados
+      Object.entries(relations).forEach(([relation, fields]) => {
+        const relationAlias = `${relation}`;
+        qb.leftJoin(`${alias}.${relation}`, relationAlias);
+        if (Array.isArray(fields) && fields.length) {
+          fields.forEach((field) => {
+            qb.addSelect(`${relationAlias}.${field}`);
+          });
+        }
+      });
+    }
   }
 
   // WHERE simple y anidado

--- a/src/common/utils/pagination/pagination-with-filters.ts
+++ b/src/common/utils/pagination/pagination-with-filters.ts
@@ -1,0 +1,112 @@
+import { Repository, SelectQueryBuilder } from 'typeorm';
+import { SearchParams } from '../../../core/domain/dto/search/search-param';
+
+export async function paginateWithFilters<T>(repository: Repository<T>, searchParams: SearchParams) {
+  const { page = 1, limit = 10, select = [], relations = {}, where = {}, order = {} } = searchParams;
+
+  const alias = repository.metadata.tableName;
+  const qb: SelectQueryBuilder<T> = repository.createQueryBuilder(alias);
+
+  // SELECT de la entidad principal
+  if (Array.isArray(select) && select.length) {
+    qb.select(select.map((field) => `${alias}.${field}`));
+  }
+
+  // RELATIONS con campos seleccionados
+  if (relations && typeof relations === 'object') {
+    Object.entries(relations).forEach(([relation, fields]) => {
+      const relationAlias = `${relation}`;
+      qb.leftJoin(`${alias}.${relation}`, relationAlias);
+      if (Array.isArray(fields) && fields.length) {
+        fields.forEach((field) => {
+          qb.addSelect(`${relationAlias}.${field}`);
+        });
+      }
+    });
+  }
+
+  // WHERE simple y anidado
+  if (where && typeof where === 'object') {
+    Object.entries(where).forEach(([key, value]) => {
+      if (typeof value === 'object' && !Array.isArray(value) && 'op' in value) {
+        const { op, value: val } = value as { op: string; value: any };
+        switch (op) {
+          case 'like':
+            qb.andWhere(`${alias}.${key} LIKE :${key}`, { [key]: `%${val}%` });
+            break;
+          case 'gte':
+            qb.andWhere(`${alias}.${key} >= :${key}`, { [key]: val });
+            break;
+          case 'lte':
+            qb.andWhere(`${alias}.${key} <= :${key}`, { [key]: val });
+            break;
+          default:
+            qb.andWhere(`${alias}.${key} = :${key}`, { [key]: val });
+        }
+      } else if (typeof value === 'object' && !Array.isArray(value)) {
+        Object.entries(value).forEach(([nestedKey, nestedValue]) => {
+          if (typeof nestedValue === 'object' && nestedValue !== null && 'op' in nestedValue) {
+            const { op, value: val } = nestedValue as { op: string; value: any };
+            switch (op) {
+              case 'like':
+                qb.andWhere(`${key}.${nestedKey} LIKE :${key}_${nestedKey}`, {
+                  [`${key}_${nestedKey}`]: `%${val}%`
+                });
+                break;
+              case 'gte':
+                qb.andWhere(`${key}.${nestedKey} >= :${key}_${nestedKey}`, {
+                  [`${key}_${nestedKey}`]: val
+                });
+                break;
+              case 'lte':
+                qb.andWhere(`${key}.${nestedKey} <= :${key}_${nestedKey}`, {
+                  [`${key}_${nestedKey}`]: val
+                });
+                break;
+              default:
+                qb.andWhere(`${key}.${nestedKey} = :${key}_${nestedKey}`, {
+                  [`${key}_${nestedKey}`]: val
+                });
+            }
+          } else {
+            qb.andWhere(`${key}.${nestedKey} = :${key}_${nestedKey}`, {
+              [`${key}_${nestedKey}`]: nestedValue
+            });
+          }
+        });
+      } else {
+        qb.andWhere(`${alias}.${key} = :${key}`, { [key]: value });
+      }
+    });
+  }
+
+  // ORDER BY
+  if (order && typeof order === 'object') {
+    Object.entries(order).forEach(([key, direction]) => {
+      if (key.includes('.')) {
+        qb.addOrderBy(key, direction);
+      } else {
+        qb.addOrderBy(`${alias}.${key}`, direction);
+      }
+    });
+  }
+
+  // PAGINACIÓN
+  qb.skip((page - 1) * limit).take(limit);
+
+  const [data, total] = await qb.getManyAndCount();
+
+  const lastPage = Math.ceil(total / limit);
+  const nextPage = page < lastPage ? page + 1 : null;
+  console.log(data);
+  return {
+    data,
+    paginationData: {
+      total,
+      currentPage: page,
+      lastPage,
+      nextPage,
+      perPage: limit
+    }
+  };
+}

--- a/src/common/utils/pagination/pagination.ts
+++ b/src/common/utils/pagination/pagination.ts
@@ -1,0 +1,27 @@
+import { FindManyOptions, Repository } from 'typeorm';
+
+export async function paginate<T>(
+  repo: Repository<T>,
+  page: number = 1,
+  limit: number = 10,
+  options: FindManyOptions<T> = {}
+) {
+  const skip = (page - 1) * limit;
+  const [data, total] = await repo.findAndCount({
+    skip,
+    take: limit,
+    ...options
+  });
+  const lastPage = Math.ceil(total / limit);
+  const nextPage = page < lastPage ? page + 1 : null;
+  return {
+    data,
+    paginationData: {
+      total,
+      currentPage: page,
+      lastPage: lastPage,
+      nextPage: nextPage,
+      perPage: limit
+    }
+  };
+}

--- a/src/core/domain/dto/card/created-card.dto.ts
+++ b/src/core/domain/dto/card/created-card.dto.ts
@@ -1,0 +1,6 @@
+export interface CreatedCardDTO {
+  id: number;
+  name: string;
+  description?: string;
+  isActive: boolean;
+}

--- a/src/core/domain/dto/pagination/pagination.result.dto.ts
+++ b/src/core/domain/dto/pagination/pagination.result.dto.ts
@@ -1,0 +1,10 @@
+export interface PaginationResult<T> {
+  data: T[];
+  paginationData: {
+    total: number;
+    currentPage: number;
+    lastPage: number;
+    nextPage: number;
+    perPage: number;
+  };
+}

--- a/src/core/domain/dto/pagination/pagintion-query-param.dto.ts
+++ b/src/core/domain/dto/pagination/pagintion-query-param.dto.ts
@@ -1,0 +1,4 @@
+export interface PaginationQueryParamDTO {
+  page?: number;
+  limit?: number;
+}

--- a/src/core/domain/dto/search/search-param.ts
+++ b/src/core/domain/dto/search/search-param.ts
@@ -1,0 +1,11 @@
+export interface SearchParams {
+  page?: number;
+  limit?: number;
+  select?: string[];
+  relations?: string[] | Record<string, string[] | boolean>;
+  where?: Record<
+    string,
+    string | number | boolean | { op: 'eq' | 'like' | 'gte' | 'lte'; value: string | number | boolean }
+  >;
+  order?: Record<string, 'ASC' | 'DESC'>;
+}

--- a/src/core/domain/dto/user/update-user-profile.dto.ts
+++ b/src/core/domain/dto/user/update-user-profile.dto.ts
@@ -1,0 +1,14 @@
+import { RestaurantDTO } from '../restaurant/restaurant.dto';
+
+export interface UpdateUserProfileDTO {
+  phone: string;
+  district: string;
+  province: string;
+  description?: string;
+  profilePicture?: string;
+  restaurant?: RestaurantDTO;
+  consumer?: {
+    userName: string;
+  };
+  admin?: any;
+}

--- a/src/core/domain/dto/user/user.dto.ts
+++ b/src/core/domain/dto/user/user.dto.ts
@@ -1,0 +1,22 @@
+import { RestaurantDTO } from '../restaurant/restaurant.dto';
+
+export interface UserDTO {
+  id: number;
+  username: string;
+  email: string;
+  sub: string;
+  emailVerified: boolean;
+  providerId: string;
+  dni: string;
+  firstName: string;
+  lastName: string;
+  phone: string;
+  profilePicture?: string;
+  district: string;
+  province: string;
+  description?: string;
+  role: 'admin' | 'consumer' | 'restaurant';
+  restaurant?: RestaurantDTO;
+  admin?: any;
+  consumer?: any;
+}

--- a/src/core/domain/repositories/card/__test__/card.entity.spec.ts
+++ b/src/core/domain/repositories/card/__test__/card.entity.spec.ts
@@ -1,0 +1,37 @@
+import { Card } from '../card.entity';
+
+describe('Card', () => {
+  const mockDate = new Date('2024-01-01');
+
+  it('should create a Card instance correctly', () => {
+    const card = new Card(1, 'Test Card', 'Description', true, false, mockDate, mockDate, mockDate);
+
+    expect(card.id).toBe(1);
+    expect(card.name).toBe('Test Card');
+    expect(card.description).toBe('Description');
+    expect(card.isActive).toBe(true);
+    expect(card.isDeleted).toBe(false);
+    expect(card.createdAt).toBe(mockDate);
+    expect(card.updatedAt).toBe(mockDate);
+    expect(card.deletedAt).toBe(mockDate);
+  });
+
+  it('should allow property modification', () => {
+    const card = new Card(1, 'Original', 'Desc', true, false, mockDate, mockDate, mockDate);
+
+    card.name = 'Updated';
+    card.isActive = false;
+
+    expect(card.name).toBe('Updated');
+    expect(card.isActive).toBe(false);
+  });
+
+  it('should have correct property types', () => {
+    const card = new Card(1, 'Test', 'Desc', true, false, mockDate, mockDate, mockDate);
+
+    expect(typeof card.id).toBe('number');
+    expect(typeof card.name).toBe('string');
+    expect(typeof card.isActive).toBe('boolean');
+    expect(card.createdAt).toBeInstanceOf(Date);
+  });
+});

--- a/src/core/domain/repositories/card/card.entity.ts
+++ b/src/core/domain/repositories/card/card.entity.ts
@@ -1,0 +1,23 @@
+export interface ICard {
+  id: number;
+  name: string;
+  description?: string;
+  isActive: boolean;
+  isDeleted: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date;
+}
+
+export class Card implements ICard {
+  constructor(
+    public id: number,
+    public name: string,
+    public description: string,
+    public isActive: boolean,
+    public isDeleted: boolean,
+    public createdAt: Date,
+    public updatedAt: Date,
+    public deletedAt: Date
+  ) {}
+}

--- a/src/core/domain/repositories/card/card.repository.interface.ts
+++ b/src/core/domain/repositories/card/card.repository.interface.ts
@@ -1,0 +1,5 @@
+import { CreatedCardDTO } from '../../dto/card/created-card.dto';
+
+export interface ICardRepositoryInterface {
+  createCard(data: Omit<CreatedCardDTO, 'id' | 'isActive'>, restaurantId: number): Promise<CreatedCardDTO | null>;
+}

--- a/src/core/domain/repositories/user/user.repository.interface.ts
+++ b/src/core/domain/repositories/user/user.repository.interface.ts
@@ -7,4 +7,5 @@ import { UserDTO } from '../../dto/user/user.dto';
 export interface IUserProfileRepository {
   registerInfoUser(sub: string, user: Omit<UserProfileDTO, 'imageUrl'>): Promise<UserProfileDTO>;
   getAllUsers(params: PaginationQueryParamDTO, filters: SearchParams): Promise<PaginationResult<UserDTO>>;
+  deleteUser(id: number): Promise<boolean>;
 }

--- a/src/core/domain/repositories/user/user.repository.interface.ts
+++ b/src/core/domain/repositories/user/user.repository.interface.ts
@@ -1,5 +1,10 @@
+import { PaginationResult } from '../../dto/pagination/pagination.result.dto';
+import { PaginationQueryParamDTO } from '../../dto/pagination/pagintion-query-param.dto';
+import { SearchParams } from '../../dto/search/search-param';
 import { UserProfileDTO } from '../../dto/user/user-profile.dto';
+import { UserDTO } from '../../dto/user/user.dto';
 
 export interface IUserProfileRepository {
   registerInfoUser(sub: string, user: Omit<UserProfileDTO, 'imageUrl'>): Promise<UserProfileDTO>;
+  getAllUsers(params: PaginationQueryParamDTO, filters: SearchParams): Promise<PaginationResult<UserDTO>>;
 }

--- a/src/core/domain/repositories/user/user.repository.interface.ts
+++ b/src/core/domain/repositories/user/user.repository.interface.ts
@@ -1,6 +1,7 @@
 import { PaginationResult } from '../../dto/pagination/pagination.result.dto';
 import { PaginationQueryParamDTO } from '../../dto/pagination/pagintion-query-param.dto';
 import { SearchParams } from '../../dto/search/search-param';
+import { UpdateUserProfileDTO } from '../../dto/user/update-user-profile.dto';
 import { UserProfileDTO } from '../../dto/user/user-profile.dto';
 import { UserDTO } from '../../dto/user/user.dto';
 
@@ -8,4 +9,5 @@ export interface IUserProfileRepository {
   registerInfoUser(sub: string, user: Omit<UserProfileDTO, 'imageUrl'>): Promise<UserProfileDTO>;
   getAllUsers(params: PaginationQueryParamDTO, filters: SearchParams): Promise<PaginationResult<UserDTO>>;
   deleteUser(id: number): Promise<boolean>;
+  updateUserProfile(sub: string, user: UpdateUserProfileDTO): Promise<UpdateUserProfileDTO>;
 }

--- a/src/core/use-cases/card/__test__/create-card.use-case.spec.ts
+++ b/src/core/use-cases/card/__test__/create-card.use-case.spec.ts
@@ -1,0 +1,48 @@
+import { CreateCardUseCase } from '../create-card.use-case';
+import { CreateCardDTO } from '../../../../interfaces/dto/card/request/create-card.dto';
+import { ICardRepositoryInterface } from '../../../domain/repositories/card/card.repository.interface';
+import { CardCreatedDTO } from '../../../../interfaces/dto/card/response/card-created.dto';
+
+describe('CreateCardUseCase', () => {
+  let useCase: CreateCardUseCase;
+  let mockRepository: jest.Mocked<ICardRepositoryInterface>;
+
+  beforeEach(() => {
+    mockRepository = {
+      createCard: jest.fn()
+    } as any;
+
+    useCase = new CreateCardUseCase(mockRepository);
+  });
+
+  const createDto: CreateCardDTO = {
+    name: 'Test Card',
+    description: 'Test Description'
+  };
+
+  const expectedResponse: CardCreatedDTO = {
+    id: 1,
+    name: 'Test Card',
+    description: 'Test Description',
+    isActive: true
+  };
+
+  describe('execute', () => {
+    test('should create card successfully', async () => {
+      mockRepository.createCard.mockResolvedValue(expectedResponse);
+
+      const result = await useCase.excute(createDto, 1);
+
+      expect(mockRepository.createCard).toHaveBeenCalledWith(createDto, 1);
+      expect(result).toEqual(expectedResponse);
+    });
+
+    test('should throw error when restaurant not found', async () => {
+      mockRepository.createCard.mockResolvedValue(null);
+
+      await expect(useCase.excute(createDto, 999)).rejects.toThrow('Restaurant not found');
+
+      expect(mockRepository.createCard).toHaveBeenCalledWith(createDto, 999);
+    });
+  });
+});

--- a/src/core/use-cases/card/create-card.use-case.ts
+++ b/src/core/use-cases/card/create-card.use-case.ts
@@ -1,0 +1,15 @@
+import { CreateCardDTO } from '../../../interfaces/dto/card/request/create-card.dto';
+import { CardCreatedDTO } from '../../../interfaces/dto/card/response/card-created.dto';
+import { ICardRepositoryInterface } from '../../domain/repositories/card/card.repository.interface';
+
+export class CreateCardUseCase {
+  constructor(private readonly cardRepostiroy: ICardRepositoryInterface) {}
+
+  async excute(data: CreateCardDTO, restaurantId: number): Promise<CardCreatedDTO> {
+    const card = await this.cardRepostiroy.createCard(data, restaurantId);
+    if (!card) {
+      throw new Error('Restaurant not found');
+    }
+    return card;
+  }
+}

--- a/src/core/use-cases/user/__test__/delete-user.use-case.spec.ts
+++ b/src/core/use-cases/user/__test__/delete-user.use-case.spec.ts
@@ -1,0 +1,88 @@
+import { IUserProfileRepository } from '../../../domain/repositories/user/user.repository.interface';
+import { DeleteUserUseCase } from '../delete-user.use-case';
+
+describe('DeleteUserUseCase', () => {
+  let useCase: DeleteUserUseCase;
+  let mockUserProfileRepository: jest.Mocked<IUserProfileRepository>;
+
+  beforeEach(() => {
+    mockUserProfileRepository = {
+      deleteUser: jest.fn(),
+      getAllUsers: jest.fn(),
+      registerInfoUser: jest.fn() // Ajusta según tu interfaz real
+    } as any;
+
+    useCase = new DeleteUserUseCase(mockUserProfileRepository);
+  });
+
+  test('debe eliminar un usuario existente correctamente', async () => {
+    const userId = 1;
+
+    mockUserProfileRepository.deleteUser.mockResolvedValue(true);
+
+    const result = await useCase.excute(userId);
+
+    expect(mockUserProfileRepository.deleteUser).toHaveBeenCalledWith(userId);
+    expect(result).toBeUndefined();
+  });
+
+  test('debe lanzar error cuando el usuario no existe', async () => {
+    const userId = 999;
+
+    mockUserProfileRepository.deleteUser.mockResolvedValue(false);
+
+    await expect(useCase.excute(userId)).rejects.toThrow('Usuario no encontrado');
+    expect(mockUserProfileRepository.deleteUser).toHaveBeenCalledWith(userId);
+  });
+
+  test('debe lanzar error cuando el repositorio retorna false', async () => {
+    const userId = 999;
+
+    mockUserProfileRepository.deleteUser.mockResolvedValue(false);
+
+    await expect(useCase.excute(userId)).rejects.toThrow('Usuario no encontrado');
+    expect(mockUserProfileRepository.deleteUser).toHaveBeenCalledWith(userId);
+  });
+
+  test('debe manejar errores del repositorio', async () => {
+    const userId = 1;
+
+    mockUserProfileRepository.deleteUser.mockRejectedValue(new Error('Error en base de datos'));
+
+    await expect(useCase.excute(userId)).rejects.toThrow('Error en base de datos');
+    expect(mockUserProfileRepository.deleteUser).toHaveBeenCalledWith(userId);
+  });
+
+  test('debe llamar al repositorio con el ID correcto', async () => {
+    const userId = 42;
+
+    mockUserProfileRepository.deleteUser.mockResolvedValue(true);
+
+    await useCase.excute(userId);
+
+    expect(mockUserProfileRepository.deleteUser).toHaveBeenCalledTimes(1);
+    expect(mockUserProfileRepository.deleteUser).toHaveBeenCalledWith(42);
+  });
+
+  test('debe manejar eliminación exitosa independientemente del tipo de usuario', async () => {
+    const userId = 5;
+
+    mockUserProfileRepository.deleteUser.mockResolvedValue(true);
+
+    const result = await useCase.excute(userId);
+
+    expect(mockUserProfileRepository.deleteUser).toHaveBeenCalledWith(userId);
+    expect(result).toBeUndefined();
+  });
+
+  test('debe funcionar correctamente con diferentes IDs', async () => {
+    const userId = 10;
+
+    mockUserProfileRepository.deleteUser.mockResolvedValue(true);
+
+    await useCase.excute(userId);
+
+    expect(mockUserProfileRepository.deleteUser).toHaveBeenCalledWith(10);
+    expect(mockUserProfileRepository.deleteUser).toHaveBeenCalledWith(expect.any(Number));
+  });
+});

--- a/src/core/use-cases/user/__test__/get-all-users.use-case.spec.ts
+++ b/src/core/use-cases/user/__test__/get-all-users.use-case.spec.ts
@@ -1,0 +1,316 @@
+import { PaginationQueryParamDTO } from '../../../../interfaces/dto/pagination/request/pagination-query-param.dto';
+import { SearchUserDto } from '../../../../interfaces/dto/search/search-filters.dto';
+import { PaginationResponseUsers } from '../../../../interfaces/dto/user/response/pagination-users.dto';
+import { IUserProfileRepository } from '../../../domain/repositories/user/user.repository.interface';
+import { GetAllUsersUseCase } from '../get-all-users.use-case';
+
+describe('GetAllUsersUseCase', () => {
+  let useCase: GetAllUsersUseCase;
+  let mockUserProfileRepository: jest.Mocked<IUserProfileRepository>;
+
+  beforeEach(() => {
+    mockUserProfileRepository = {
+      getAllUsers: jest.fn(),
+      registerInfoUser: jest.fn() // Ajusta según tu interfaz real
+    } as any;
+
+    useCase = new GetAllUsersUseCase(mockUserProfileRepository);
+  });
+
+  const paginationParams: PaginationQueryParamDTO = {
+    page: 1,
+    limit: 10
+  };
+
+  const searchFilters: SearchUserDto = {
+    select: ['dni', 'firstName', 'lastName'],
+    where: {
+      role: 'admin',
+      district: { op: 'like', value: 'Miraflores' }
+    },
+    order: {
+      firstName: 'ASC'
+    }
+  };
+
+  const expectedResponse: PaginationResponseUsers = {
+    data: [
+      {
+        id: 1,
+        username: 'juan.perez',
+        sub: 'user-sub-123',
+        emailVerified: true,
+        providerId: 'auth0|123456',
+        dni: '12345678',
+        firstName: 'Juan',
+        lastName: 'Pérez',
+        phone: '987654321',
+        email: 'juan.perez@example.com',
+        profilePicture: 'https://example.com/profile1.jpg',
+        district: 'Miraflores',
+        province: 'Lima',
+        role: 'admin',
+        description: 'Administrador del sistema',
+        admin: {
+          // Ajusta según AdminResponseDTO
+        }
+      },
+      {
+        id: 2,
+        username: 'maria.garcia',
+        sub: 'user-sub-456',
+        emailVerified: true,
+        providerId: 'auth0|789012',
+        dni: '87654321',
+        firstName: 'María',
+        lastName: 'García',
+        phone: '123456789',
+        email: 'maria.garcia@example.com',
+        district: 'San Isidro',
+        province: 'Lima',
+        role: 'consumer',
+        consumer: {
+          userName: 'Luis',
+          isDeleted: false
+        }
+      }
+    ],
+    paginationData: {
+      total: 2,
+      currentPage: 1,
+      lastPage: 1,
+      nextPage: 1,
+      perPage: 10
+    }
+  };
+
+  test('debe obtener y devolver usuarios paginados con filtros', async () => {
+    mockUserProfileRepository.getAllUsers.mockResolvedValue(expectedResponse);
+
+    const result = await useCase.execute(paginationParams, searchFilters);
+
+    expect(mockUserProfileRepository.getAllUsers).toHaveBeenCalledWith(paginationParams, searchFilters);
+    expect(result).toEqual(expectedResponse);
+  });
+
+  test('debe obtener usuarios con parámetros de paginación por defecto', async () => {
+    const defaultPagination: PaginationQueryParamDTO = {
+      page: 1,
+      limit: 10
+    };
+    const emptyFilters: SearchUserDto = {};
+
+    mockUserProfileRepository.getAllUsers.mockResolvedValue(expectedResponse);
+
+    const result = await useCase.execute(defaultPagination, emptyFilters);
+
+    expect(mockUserProfileRepository.getAllUsers).toHaveBeenCalledWith(defaultPagination, emptyFilters);
+    expect(result).toEqual(expectedResponse);
+  });
+
+  test('debe manejar filtros con operadores complejos', async () => {
+    const complexFilters: SearchUserDto = {
+      select: ['dni', 'firstName', 'lastName', 'role'],
+      where: {
+        firstName: { op: 'like', value: 'Juan%' },
+        age: { op: 'gte', value: 18 }
+      },
+      order: {
+        lastName: 'DESC',
+        firstName: 'ASC'
+      },
+      relations: ['profile', 'permissions']
+    };
+
+    mockUserProfileRepository.getAllUsers.mockResolvedValue(expectedResponse);
+
+    const result = await useCase.execute(paginationParams, complexFilters);
+
+    expect(mockUserProfileRepository.getAllUsers).toHaveBeenCalledWith(paginationParams, complexFilters);
+    expect(result).toEqual(expectedResponse);
+  });
+
+  test('debe manejar paginación con diferentes valores', async () => {
+    const customPagination: PaginationQueryParamDTO = {
+      page: 2,
+      limit: 5
+    };
+
+    const paginatedResponse: PaginationResponseUsers = {
+      data: [
+        {
+          id: 2,
+          username: 'maria.garcia',
+          sub: 'user-sub-456',
+          emailVerified: true,
+          providerId: 'auth0|789012',
+          dni: '87654321',
+          firstName: 'María',
+          lastName: 'García',
+          phone: '123456789',
+          email: 'maria.garcia@example.com',
+          district: 'San Isidro',
+          province: 'Lima',
+          role: 'consumer'
+        }
+      ],
+      paginationData: {
+        total: 15,
+        currentPage: 2,
+        lastPage: 3,
+        nextPage: 3,
+        perPage: 5
+      }
+    };
+
+    mockUserProfileRepository.getAllUsers.mockResolvedValue(paginatedResponse);
+
+    const result = await useCase.execute(customPagination, searchFilters);
+
+    expect(mockUserProfileRepository.getAllUsers).toHaveBeenCalledWith(customPagination, searchFilters);
+    expect(result).toEqual(paginatedResponse);
+    expect(result.paginationData.currentPage).toBe(2);
+    expect(result.paginationData.nextPage).toBe(3);
+    expect(result.paginationData.lastPage).toBe(3);
+  });
+
+  test('debe lanzar un error si falla el repositorio', async () => {
+    mockUserProfileRepository.getAllUsers.mockRejectedValue(new Error('Error en base de datos'));
+
+    await expect(useCase.execute(paginationParams, searchFilters)).rejects.toThrow('Error en base de datos');
+    expect(mockUserProfileRepository.getAllUsers).toHaveBeenCalledWith(paginationParams, searchFilters);
+  });
+
+  test('debe manejar respuesta vacía', async () => {
+    const emptyResponse: PaginationResponseUsers = {
+      data: [],
+      paginationData: {
+        total: 0,
+        currentPage: 1,
+        lastPage: 0,
+        nextPage: 0,
+        perPage: 10
+      }
+    };
+
+    mockUserProfileRepository.getAllUsers.mockResolvedValue(emptyResponse);
+
+    const result = await useCase.execute(paginationParams, searchFilters);
+
+    expect(mockUserProfileRepository.getAllUsers).toHaveBeenCalledWith(paginationParams, searchFilters);
+    expect(result).toEqual(emptyResponse);
+    expect(result.data).toHaveLength(0);
+    expect(result.paginationData.total).toBe(0);
+  });
+
+  test('debe manejar filtros por rol específico', async () => {
+    const roleFilters: SearchUserDto = {
+      where: {
+        role: 'consumer'
+      }
+    };
+
+    const consumerResponse: PaginationResponseUsers = {
+      data: [
+        {
+          id: 4,
+          username: 'ana.consumer',
+          sub: 'user-sub-101',
+          emailVerified: true,
+          providerId: 'auth0|101112',
+          dni: '22222222',
+          firstName: 'Ana',
+          lastName: 'Consumidora',
+          phone: '999888777',
+          email: 'ana.consumer@example.com',
+          district: 'Barranco',
+          province: 'Lima',
+          role: 'consumer',
+          consumer: {
+            userName: 'Luis',
+            isDeleted: false
+          }
+        }
+      ],
+      paginationData: {
+        total: 1,
+        currentPage: 1,
+        lastPage: 1,
+        nextPage: 1,
+        perPage: 10
+      }
+    };
+
+    mockUserProfileRepository.getAllUsers.mockResolvedValue(consumerResponse);
+
+    const result = await useCase.execute(paginationParams, roleFilters);
+
+    expect(mockUserProfileRepository.getAllUsers).toHaveBeenCalledWith(paginationParams, roleFilters);
+    expect(result).toEqual(consumerResponse);
+    expect(result.data[0].role).toBe('consumer');
+    expect(result.data[0]).toHaveProperty('consumer');
+    expect(result.data[0].consumer).toBeDefined();
+  });
+
+  test('debe manejar usuario con restaurant', async () => {
+    const restaurantFilters: SearchUserDto = {
+      where: {
+        role: 'restaurant'
+      },
+      relations: ['restaurant']
+    };
+
+    const restaurantResponse: PaginationResponseUsers = {
+      data: [
+        {
+          id: 5,
+          username: 'restaurant.owner',
+          sub: 'user-sub-202',
+          emailVerified: true,
+          providerId: 'auth0|202203',
+          dni: '33333333',
+          firstName: 'Pedro',
+          lastName: 'Restaurantero',
+          phone: '111222333',
+          email: 'pedro@restaurant.com',
+          district: 'Miraflores',
+          province: 'Lima',
+          role: 'restaurant',
+          description: 'Propietario de restaurante',
+          restaurant: {
+            id: 1,
+            name: 'Mi Restaurante Saludable',
+            mapsAddress: 'Av. Siempre Viva 123, Lima',
+            latitude: -12.04318,
+            longitude: -77.02824,
+            ruc: '20123456789',
+            legalName: 'Mi Empresa S.A.C.',
+            whatsappOrders: '987654321',
+            yapePhone: '987654321',
+            logoUrl: 'https://example.com/logo.png',
+            bannerUrl: 'https://example.com/banner.jpg',
+            dinerIn: true,
+            delivery: true
+          }
+        }
+      ],
+      paginationData: {
+        total: 1,
+        currentPage: 1,
+        lastPage: 1,
+        nextPage: 1,
+        perPage: 10
+      }
+    };
+
+    mockUserProfileRepository.getAllUsers.mockResolvedValue(restaurantResponse);
+
+    const result = await useCase.execute(paginationParams, restaurantFilters);
+
+    expect(mockUserProfileRepository.getAllUsers).toHaveBeenCalledWith(paginationParams, restaurantFilters);
+    expect(result).toEqual(restaurantResponse);
+    expect(result.data[0].role).toBe('restaurant');
+    expect(result.data[0]).toHaveProperty('restaurant');
+    expect(result.data[0].restaurant).toBeDefined();
+  });
+});

--- a/src/core/use-cases/user/__test__/update-user-profile.use-case.spec.ts
+++ b/src/core/use-cases/user/__test__/update-user-profile.use-case.spec.ts
@@ -1,0 +1,67 @@
+import { IUserProfileRepository } from '../../../domain/repositories/user/user.repository.interface';
+import { UpdateUserProfileUseCase } from '../update-user-profile.use-case';
+import { UpdateUserProfileDTO } from '../../../../interfaces/dto/user/request/update-user-profile.dto';
+import { UserUpdateProfileDTO } from '../../../../interfaces/dto/user/response/user-update-profile.dto';
+
+describe('UpdateUserProfileUseCase', () => {
+  let useCase: UpdateUserProfileUseCase;
+  let mockUserProfileRepository: jest.Mocked<IUserProfileRepository>;
+
+  beforeEach(() => {
+    mockUserProfileRepository = {
+      updateUserProfile: jest.fn()
+    } as any;
+
+    useCase = new UpdateUserProfileUseCase(mockUserProfileRepository);
+  });
+
+  const sub = 'user-sub-123';
+  const updateDto: UpdateUserProfileDTO = {
+    phone: '123456789',
+    district: 'San Isidro',
+    province: 'Lima'
+  };
+
+  const expectedResponse: UserUpdateProfileDTO = {
+    phone: '123456789',
+    district: 'San Isidro',
+    province: 'Lima'
+  };
+
+  test('debe actualizar y devolver el perfil de usuario', async () => {
+    mockUserProfileRepository.updateUserProfile.mockResolvedValue(expectedResponse);
+
+    const result = await useCase.execute(sub, updateDto);
+
+    expect(mockUserProfileRepository.updateUserProfile).toHaveBeenCalledWith(sub, updateDto);
+    expect(result).toEqual(expectedResponse);
+  });
+
+  test('debe lanzar un error si falla el repositorio', async () => {
+    mockUserProfileRepository.updateUserProfile.mockRejectedValue(new Error('Error en base de datos'));
+
+    await expect(useCase.execute(sub, updateDto)).rejects.toThrow('Error en base de datos');
+    expect(mockUserProfileRepository.updateUserProfile).toHaveBeenCalledWith(sub, updateDto);
+  });
+
+  test('debe manejar datos parciales para actualización', async () => {
+    const partialUpdateDto: UpdateUserProfileDTO = {
+      phone: '555123456',
+      district: 'Los Olivos',
+      province: 'Lima'
+    };
+
+    const partialResponse: UserUpdateProfileDTO = {
+      phone: '555123456',
+      district: 'Los Olivos',
+      province: 'Lima'
+    };
+
+    mockUserProfileRepository.updateUserProfile.mockResolvedValue(partialResponse);
+
+    const result = await useCase.execute(sub, partialUpdateDto);
+
+    expect(mockUserProfileRepository.updateUserProfile).toHaveBeenCalledWith(sub, partialUpdateDto);
+    expect(result).toEqual(partialResponse);
+  });
+});

--- a/src/core/use-cases/user/delete-user.use-case.ts
+++ b/src/core/use-cases/user/delete-user.use-case.ts
@@ -1,0 +1,12 @@
+import { IUserProfileRepository } from '../../domain/repositories/user/user.repository.interface';
+
+export class DeleteUserUseCase {
+  constructor(private readonly userRepository: IUserProfileRepository) {}
+  async excute(id: number): Promise<void> {
+    const user = await this.userRepository.deleteUser(id);
+    if (!user) {
+      throw new Error('Usuario no encontrado');
+    }
+    return;
+  }
+}

--- a/src/core/use-cases/user/get-all-users.use-case.ts
+++ b/src/core/use-cases/user/get-all-users.use-case.ts
@@ -1,0 +1,12 @@
+import { PaginationQueryParamDTO } from '../../../interfaces/dto/pagination/request/pagination-query-param.dto';
+import { SearchUserDto } from '../../../interfaces/dto/search/search-filters.dto';
+import { PaginationResponseUsers } from '../../../interfaces/dto/user/response/pagination-users.dto';
+import { IUserProfileRepository } from '../../domain/repositories/user/user.repository.interface';
+
+export class GetAllUsersUseCase {
+  constructor(private readonly userRepository: IUserProfileRepository) {}
+  async execute(params: PaginationQueryParamDTO, filters: SearchUserDto): Promise<PaginationResponseUsers> {
+    const users = await this.userRepository.getAllUsers(params, filters);
+    return users;
+  }
+}

--- a/src/core/use-cases/user/update-user-profile.use-case.ts
+++ b/src/core/use-cases/user/update-user-profile.use-case.ts
@@ -1,0 +1,11 @@
+import { UpdateUserProfileDTO } from '../../../interfaces/dto/user/request/update-user-profile.dto';
+import { UserUpdateProfileDTO } from '../../../interfaces/dto/user/response/user-update-profile.dto';
+import { IUserProfileRepository } from '../../domain/repositories/user/user.repository.interface';
+
+export class UpdateUserProfileUseCase {
+  constructor(private readonly userRepository: IUserProfileRepository) {}
+  async execute(sub: string, userData: UpdateUserProfileDTO): Promise<UserUpdateProfileDTO> {
+    const user = await this.userRepository.updateUserProfile(sub, userData);
+    return user;
+  }
+}

--- a/src/infrastructure/database/entities/card/card.entity.ts
+++ b/src/infrastructure/database/entities/card/card.entity.ts
@@ -1,0 +1,42 @@
+import {
+  Column,
+  CreateDateColumn,
+  DeleteDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn
+} from 'typeorm';
+import { RestaurantEntity } from '../restaurant/restaurant.entity';
+
+@Entity('cards')
+export class CardEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => RestaurantEntity, (restaurant) => restaurant.card)
+  @JoinColumn({ name: 'restaurant_id' })
+  restaurant: RestaurantEntity;
+
+  @Column()
+  name: string;
+
+  @Column()
+  description?: string;
+
+  @Column({ name: 'is_active', default: true })
+  isActive: boolean;
+
+  @Column({ name: 'is_deleted', default: false })
+  isDeleted: boolean;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+
+  @DeleteDateColumn({ name: 'deleted_at' })
+  deletedAt: Date;
+}

--- a/src/infrastructure/database/entities/card/repository/__test__/typeorm-card-repository.spec.ts
+++ b/src/infrastructure/database/entities/card/repository/__test__/typeorm-card-repository.spec.ts
@@ -1,0 +1,92 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { TypeOrmCardRepository } from '../typeorm-card.repository';
+import { CardEntity } from '../../card.entity';
+import { RestaurantEntity } from '../../../restaurant/restaurant.entity';
+import { CreatedCardDTO } from '../../../../../../core/domain/dto/card/created-card.dto';
+
+describe('TypeOrmCardRepository', () => {
+  let repository: TypeOrmCardRepository;
+  let cardRepo: jest.Mocked<Repository<CardEntity>>;
+  let restaurantRepo: jest.Mocked<Repository<RestaurantEntity>>;
+
+  const mockRestaurant = {
+    id: 1,
+    name: 'Test Restaurant'
+  } as RestaurantEntity;
+
+  const mockCardData = {
+    name: 'Test Card',
+    description: 'Test Description',
+    isDeleted: false,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    deletedAt: new Date()
+  };
+
+  const mockSavedCard = {
+    id: 1,
+    ...mockCardData,
+    isActive: true,
+    restaurant: mockRestaurant
+  } as CreatedCardDTO;
+
+  beforeEach(async () => {
+    const mockCardRepository = {
+      create: jest.fn(),
+      save: jest.fn()
+    };
+
+    const mockRestaurantRepository = {
+      findOne: jest.fn()
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TypeOrmCardRepository,
+        {
+          provide: getRepositoryToken(CardEntity),
+          useValue: mockCardRepository
+        },
+        {
+          provide: getRepositoryToken(RestaurantEntity),
+          useValue: mockRestaurantRepository
+        }
+      ]
+    }).compile();
+
+    repository = module.get<TypeOrmCardRepository>(TypeOrmCardRepository);
+    cardRepo = module.get(getRepositoryToken(CardEntity));
+    restaurantRepo = module.get(getRepositoryToken(RestaurantEntity));
+  });
+
+  describe('createCard', () => {
+    it('should create card successfully when restaurant exists', async () => {
+      restaurantRepo.findOne.mockResolvedValue(mockRestaurant);
+      cardRepo.create.mockReturnValue(mockSavedCard as any);
+      cardRepo.save.mockResolvedValue(mockSavedCard as any);
+
+      const result = await repository.createCard(mockCardData, 1);
+
+      expect(restaurantRepo.findOne).toHaveBeenCalledWith({ where: { id: 1 } });
+      expect(cardRepo.create).toHaveBeenCalledWith({
+        ...mockCardData,
+        restaurant: mockRestaurant
+      });
+      expect(cardRepo.save).toHaveBeenCalled();
+      expect(result).toEqual(mockSavedCard);
+    });
+
+    it('should return null when restaurant does not exist', async () => {
+      restaurantRepo.findOne.mockResolvedValue(null);
+
+      const result = await repository.createCard(mockCardData, 999);
+
+      expect(restaurantRepo.findOne).toHaveBeenCalledWith({ where: { id: 999 } });
+      expect(cardRepo.create).not.toHaveBeenCalled();
+      expect(cardRepo.save).not.toHaveBeenCalled();
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/src/infrastructure/database/entities/card/repository/typeorm-card.repository.ts
+++ b/src/infrastructure/database/entities/card/repository/typeorm-card.repository.ts
@@ -1,0 +1,33 @@
+import { Repository } from 'typeorm';
+import { ICardRepositoryInterface } from '../../../../../core/domain/repositories/card/card.repository.interface';
+import { CardEntity } from '../card.entity';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Injectable } from '@nestjs/common';
+import { CreatedCardDTO } from '../../../../../core/domain/dto/card/created-card.dto';
+import { RestaurantEntity } from '../../restaurant/restaurant.entity';
+
+@Injectable()
+export class TypeOrmCardRepository implements ICardRepositoryInterface {
+  constructor(
+    @InjectRepository(CardEntity)
+    private readonly cardRepository: Repository<CardEntity>,
+    @InjectRepository(RestaurantEntity)
+    private readonly retaurantRepository: Repository<RestaurantEntity>
+  ) {}
+
+  async createCard(
+    data: Omit<CreatedCardDTO, 'id' | 'isActive'>,
+    restaurantId: number
+  ): Promise<CreatedCardDTO | null> {
+    const restaurant = await this.retaurantRepository.findOne({ where: { id: restaurantId } });
+    if (!restaurant) {
+      return null;
+    }
+    const card = this.cardRepository.create({
+      ...data,
+      restaurant
+    });
+    const savedCard = await this.cardRepository.save(card);
+    return savedCard;
+  }
+}

--- a/src/infrastructure/database/entities/restaurant/restaurant.entity.ts
+++ b/src/infrastructure/database/entities/restaurant/restaurant.entity.ts
@@ -11,6 +11,7 @@ import {
 } from 'typeorm';
 import { UserEntity } from '../authentication/user.entity';
 import { OpeningHourEntity } from '../opening-hour/openings-hours.entity';
+import { CardEntity } from '../card/card.entity';
 
 @Entity('restaurants')
 export class RestaurantEntity {
@@ -26,6 +27,12 @@ export class RestaurantEntity {
     eager: false
   })
   openingHour?: OpeningHourEntity[];
+
+  @OneToMany(() => CardEntity, (card) => card.restaurant, {
+    cascade: true,
+    eager: false
+  })
+  card?: CardEntity[];
 
   @Column()
   name: string;

--- a/src/infrastructure/database/entities/user/repository/__test__/typeorm-user-profile.repository.spec.ts
+++ b/src/infrastructure/database/entities/user/repository/__test__/typeorm-user-profile.repository.spec.ts
@@ -8,6 +8,7 @@ import { AdminEntity } from '../../../admin/admin.entity';
 import { RestaurantEntity } from '../../../restaurant/restaurant.entity';
 import { OpeningHourEntity } from '../../../opening-hour/openings-hours.entity';
 import { UserProfileDTO } from '../../../../../../core/domain/dto/user/user-profile.dto';
+import { UpdateUserProfileDTO } from '../../../../../../core/domain/dto/user/update-user-profile.dto';
 
 describe('TypeOrmUserProfile', () => {
   let service: TypeOrmUserProfile;
@@ -478,6 +479,150 @@ describe('TypeOrmUserProfile', () => {
       expect(mockRepo.findOne).toHaveBeenCalledWith({ where: { id: userId } });
       expect(mockRepo.save).toHaveBeenCalled();
       expect(mockRepo.softDelete).not.toHaveBeenCalled();
+    });
+  });
+  describe('updateUserProfile', () => {
+    const sub = 'google-oauth2|1234567890';
+    const baseUser: UserEntity = {
+      id: 1,
+      sub,
+      email: 'john@example.com',
+      username: 'John Doe',
+      emailVerified: true,
+      providerId: 'google.com',
+      isDeleted: false,
+      createdAt: new Date('2025-01-01T00:00:00Z'),
+      updatedAt: new Date('2025-01-01T00:00:00Z'),
+      deleteAt: new Date('2100-01-01T00:00:00Z'),
+      dni: '12345678',
+      firstName: 'John',
+      lastName: 'Doe',
+      phone: '987654321',
+      district: 'Lima',
+      province: 'Lima',
+      role: 'consumer',
+      description: 'Usuario test'
+    };
+
+    // Agregar al beforeEach existente
+    beforeEach(() => {
+      // ... código existente ...
+      mockManager.update = jest.fn();
+      mockManager.delete = jest.fn();
+      mockManager.insert = jest.fn();
+    });
+
+    it('debe actualizar un usuario consumer correctamente', async () => {
+      const userWithConsumer = {
+        ...baseUser,
+        role: 'consumer' as const,
+        consumer: { id: 1, userName: 'OldName' }
+      };
+
+      const input: UpdateUserProfileDTO = {
+        phone: '999888777',
+        district: 'San Isidro',
+        province: 'Lima',
+        consumer: { userName: 'NewName' }
+      };
+
+      mockManager.findOne
+        .mockResolvedValueOnce(userWithConsumer)
+        .mockResolvedValueOnce({ ...userWithConsumer, ...input });
+      mockManager.update.mockResolvedValueOnce({ affected: 1, raw: {}, generatedMaps: [] });
+      mockManager.save.mockResolvedValueOnce({ ...userWithConsumer, ...input });
+
+      const result = await service.updateUserProfile(sub, input);
+
+      expect(mockManager.update).toHaveBeenCalledWith(ConsumerEntity, { id: 1 }, { userName: 'NewName' });
+      expect(mockManager.findOne).toHaveBeenLastCalledWith(UserEntity, {
+        where: { sub },
+        relations: ['consumer']
+      });
+      expect(result).toBeDefined();
+    });
+
+    it('debe actualizar un usuario restaurant con horarios correctamente', async () => {
+      const userWithRestaurant = {
+        ...baseUser,
+        role: 'restaurant' as const,
+        restaurant: { id: 1, name: 'Old Restaurant' }
+      };
+
+      const input: UpdateUserProfileDTO = {
+        phone: '555444333',
+        district: 'Miraflores',
+        province: 'Lima',
+        restaurant: {
+          name: 'New Restaurant',
+          mapsAddress: 'Nueva dirección',
+          latitude: -12.1234,
+          longitude: -77.5678,
+          dinerIn: true,
+          delivery: true,
+          openingHour: [{ weekDay: 1, startTime: '10:00', endTime: '22:00', enabled: true }]
+        }
+      };
+
+      mockManager.findOne
+        .mockResolvedValueOnce(userWithRestaurant)
+        .mockResolvedValueOnce({ ...userWithRestaurant, ...input });
+      mockManager.update.mockResolvedValueOnce({ affected: 1, raw: {}, generatedMaps: [] });
+      mockManager.delete.mockResolvedValueOnce({ affected: 1, raw: {} });
+      mockManager.insert.mockResolvedValueOnce({ identifiers: [], generatedMaps: [], raw: {} });
+      mockManager.save.mockResolvedValueOnce({ ...userWithRestaurant, ...input });
+
+      await service.updateUserProfile(sub, input);
+
+      expect(mockManager.update).toHaveBeenCalledWith(
+        RestaurantEntity,
+        { id: 1 },
+        expect.objectContaining({
+          name: 'New Restaurant',
+          mapsAddress: 'Nueva dirección',
+          latitude: -12.1234,
+          longitude: -77.5678,
+          dinerIn: true,
+          delivery: true
+        })
+      );
+      expect(mockManager.delete).toHaveBeenCalledWith(OpeningHourEntity, {
+        restaurant: { id: 1 }
+      });
+      expect(mockManager.insert).toHaveBeenCalledWith(OpeningHourEntity, [
+        expect.objectContaining({
+          weekDay: 1,
+          restaurant: { id: 1 }
+        })
+      ]);
+    });
+
+    it('debe actualizar campos básicos sin relaciones', async () => {
+      const input: UpdateUserProfileDTO = {
+        phone: '666555444',
+        district: 'Surco',
+        province: 'Lima'
+      };
+
+      mockManager.findOne.mockResolvedValueOnce(baseUser).mockResolvedValueOnce({ ...baseUser, ...input });
+      mockManager.save.mockResolvedValueOnce({ ...baseUser, ...input });
+
+      await service.updateUserProfile(sub, input);
+
+      expect(mockManager.save).toHaveBeenCalledWith(UserEntity, expect.objectContaining(input));
+      expect(mockManager.update).not.toHaveBeenCalled();
+    });
+
+    it('debe fallar cuando el usuario no existe', async () => {
+      mockManager.findOne.mockResolvedValueOnce(null);
+
+      await expect(
+        service.updateUserProfile(sub, {
+          phone: '123',
+          district: 'Test',
+          province: 'Test'
+        } as UpdateUserProfileDTO)
+      ).rejects.toThrow();
     });
   });
 });

--- a/src/infrastructure/database/entities/user/repository/typeorm-user-profile.repository.ts
+++ b/src/infrastructure/database/entities/user/repository/typeorm-user-profile.repository.ts
@@ -8,6 +8,11 @@ import { OpeningHourEntity } from '../../opening-hour/openings-hours.entity';
 import { AdminEntity } from '../../admin/admin.entity';
 import { ConsumerEntity } from '../../consumer/consumer.entity';
 import { UserProfileDTO } from '../../../../../core/domain/dto/user/user-profile.dto';
+import { PaginationResult } from '../../../../../core/domain/dto/pagination/pagination.result.dto';
+import { PaginationQueryParamDTO } from '../../../../../core/domain/dto/pagination/pagintion-query-param.dto';
+import { SearchParams } from '../../../../../core/domain/dto/search/search-param';
+import { paginateWithFilters } from '../../../../../common/utils/pagination/pagination-with-filters';
+import { UserDTO } from '../../../../../core/domain/dto/user/user.dto';
 
 @Injectable()
 export class TypeOrmUserProfile implements IUserProfileRepository {
@@ -62,5 +67,11 @@ export class TypeOrmUserProfile implements IUserProfileRepository {
       });
       return userUpdated;
     });
+  }
+
+  async getAllUsers(params: PaginationQueryParamDTO, filters: SearchParams): Promise<PaginationResult<UserDTO>> {
+    console.log(filters);
+    const users = await paginateWithFilters(this.userRepository, { ...params, ...filters });
+    return users;
   }
 }

--- a/src/infrastructure/database/entities/user/repository/typeorm-user-profile.repository.ts
+++ b/src/infrastructure/database/entities/user/repository/typeorm-user-profile.repository.ts
@@ -74,4 +74,16 @@ export class TypeOrmUserProfile implements IUserProfileRepository {
     const users = await paginateWithFilters(this.userRepository, { ...params, ...filters });
     return users;
   }
+
+  async deleteUser(id: number): Promise<boolean> {
+    const user = await this.userRepository.findOne({ where: { id: id } });
+
+    if (!user) return false;
+
+    user.isDeleted = true;
+    await this.userRepository.save(user);
+
+    await this.userRepository.softDelete(id);
+    return true;
+  }
 }

--- a/src/interfaces/controllers/card/restaurant.controller.ts
+++ b/src/interfaces/controllers/card/restaurant.controller.ts
@@ -1,0 +1,34 @@
+import { Body, Controller, HttpException, HttpStatus, Param, ParseIntPipe, Post } from '@nestjs/common';
+import { ApiBody, ApiCreatedResponse, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
+import { CreateCardUseCase } from '../../../core/use-cases/card/create-card.use-case';
+import { CreateCardDTO } from '../../dto/card/request/create-card.dto';
+import { plainToInstance } from 'class-transformer';
+import { CardCreatedDTO } from '../../dto/card/response/card-created.dto';
+
+@ApiTags('restaurants')
+@Controller({ path: 'restaurants', version: '1' })
+export class CardController {
+  constructor(private readonly createCardUseCase: CreateCardUseCase) {}
+
+  @Post(':restaurantId/cards')
+  @ApiParam({
+    name: 'restaurantId',
+    type: Number,
+    description: 'Id del restaurante',
+    example: 1
+  })
+  @ApiOperation({ summary: 'Creacion de cartas relacionadas al restaurante' })
+  @ApiBody({ type: CreateCardDTO })
+  @ApiCreatedResponse({
+    description: 'Carta creada',
+    type: CardCreatedDTO
+  })
+  async createCard(@Param('restaurantId', ParseIntPipe) restaurantId: number, @Body() data: CreateCardDTO) {
+    try {
+      const card = await this.createCardUseCase.excute(data, restaurantId);
+      return plainToInstance(CardCreatedDTO, card);
+    } catch (error) {
+      throw new HttpException(error.message, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+}

--- a/src/interfaces/controllers/user/user.controller.ts
+++ b/src/interfaces/controllers/user/user.controller.ts
@@ -1,5 +1,5 @@
-import { Body, Controller, HttpException, HttpStatus, Post, Req, UseGuards } from '@nestjs/common';
-import { ApiBody, ApiCreatedResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { Body, Controller, Get, HttpException, HttpStatus, Post, Query, Req, UseGuards } from '@nestjs/common';
+import { ApiBody, ApiCreatedResponse, ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { Request } from 'express';
 import { plainToInstance } from 'class-transformer';
 import { JwtAuthGuard } from '../../../common/guards/jwt-auth.guard';
@@ -7,12 +7,19 @@ import { UserExistGuad } from '../../../common/guards/user-exists.guard';
 import { UserCreateProfileUseCase } from '../../../core/use-cases/user/user-create-profile.use-case';
 import { RegisterUserProfileDto } from '../../dto/user/request/create-user-profile.dto';
 import { UserRegisterProfileDTO } from '../../dto/user/response/user-profile.dto';
+import { GetAllUsersUseCase } from '../../../core/use-cases/user/get-all-users.use-case';
+import { PaginationResponseUsers } from '../../dto/user/response/pagination-users.dto';
+import { PaginationQueryParamDTO } from '../../dto/pagination/request/pagination-query-param.dto';
+import { SearchUserDto } from '../../dto/search/search-filters.dto';
 
 @UseGuards(JwtAuthGuard, UserExistGuad)
 @ApiTags('users')
 @Controller({ path: 'users', version: '1' })
 export class UserController {
-  constructor(private readonly userCreateProfileUseCase: UserCreateProfileUseCase) {}
+  constructor(
+    private readonly userCreateProfileUseCase: UserCreateProfileUseCase,
+    private readonly getAllUsersUseCase: GetAllUsersUseCase
+  ) {}
 
   @Post('profile')
   @ApiOperation({ summary: 'Registrar el perfil del usuario' })
@@ -28,6 +35,23 @@ export class UserController {
       return plainToInstance(UserRegisterProfileDTO, profileRegister);
     } catch (error) {
       throw new HttpException(error.message, HttpStatus.BAD_REQUEST);
+    }
+  }
+  @Get('')
+  @ApiOperation({ summary: 'Listado y filtrado de usuarios' })
+  @ApiBody({ type: SearchUserDto })
+  @ApiQuery({ type: PaginationQueryParamDTO })
+  @ApiCreatedResponse({
+    description: 'Listado de usuarios',
+    type: PaginationResponseUsers
+  })
+  async getAllUsers(@Query() params: PaginationQueryParamDTO, @Body() filters: SearchUserDto) {
+    try {
+      const users = await this.getAllUsersUseCase.execute(params, filters);
+      const data = plainToInstance(PaginationResponseUsers, users);
+      return data;
+    } catch (error) {
+      throw new HttpException(error.message, HttpStatus.INTERNAL_SERVER_ERROR);
     }
   }
 }

--- a/src/interfaces/controllers/user/user.controller.ts
+++ b/src/interfaces/controllers/user/user.controller.ts
@@ -1,5 +1,18 @@
-import { Body, Controller, Get, HttpException, HttpStatus, Post, Query, Req, UseGuards } from '@nestjs/common';
-import { ApiBody, ApiCreatedResponse, ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpException,
+  HttpStatus,
+  Param,
+  ParseIntPipe,
+  Post,
+  Query,
+  Req,
+  UseGuards
+} from '@nestjs/common';
+import { ApiBody, ApiCreatedResponse, ApiOperation, ApiParam, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { Request } from 'express';
 import { plainToInstance } from 'class-transformer';
 import { JwtAuthGuard } from '../../../common/guards/jwt-auth.guard';
@@ -11,6 +24,7 @@ import { GetAllUsersUseCase } from '../../../core/use-cases/user/get-all-users.u
 import { PaginationResponseUsers } from '../../dto/user/response/pagination-users.dto';
 import { PaginationQueryParamDTO } from '../../dto/pagination/request/pagination-query-param.dto';
 import { SearchUserDto } from '../../dto/search/search-filters.dto';
+import { DeleteUserUseCase } from '../../../core/use-cases/user/delete-user.use-case';
 
 @UseGuards(JwtAuthGuard, UserExistGuad)
 @ApiTags('users')
@@ -18,7 +32,8 @@ import { SearchUserDto } from '../../dto/search/search-filters.dto';
 export class UserController {
   constructor(
     private readonly userCreateProfileUseCase: UserCreateProfileUseCase,
-    private readonly getAllUsersUseCase: GetAllUsersUseCase
+    private readonly getAllUsersUseCase: GetAllUsersUseCase,
+    private readonly deleteUserUseCase: DeleteUserUseCase
   ) {}
 
   @Post('profile')
@@ -52,6 +67,29 @@ export class UserController {
       return data;
     } catch (error) {
       throw new HttpException(error.message, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  @Delete(':id')
+  @ApiParam({
+    name: 'id',
+    type: Number,
+    description: 'Id del usuario',
+    example: 1
+  })
+  @ApiCreatedResponse({
+    example: {
+      message: 'Usuario eliminado'
+    }
+  })
+  async deleteUser(@Param('id', ParseIntPipe) id: number) {
+    try {
+      await this.deleteUserUseCase.excute(id);
+      return {
+        message: 'Usuario eliminado'
+      };
+    } catch (error) {
+      throw new HttpException(error.message, HttpStatus.NOT_FOUND);
     }
   }
 }

--- a/src/interfaces/controllers/user/user.controller.ts
+++ b/src/interfaces/controllers/user/user.controller.ts
@@ -8,6 +8,7 @@ import {
   Param,
   ParseIntPipe,
   Post,
+  Put,
   Query,
   Req,
   UseGuards
@@ -25,6 +26,9 @@ import { PaginationResponseUsers } from '../../dto/user/response/pagination-user
 import { PaginationQueryParamDTO } from '../../dto/pagination/request/pagination-query-param.dto';
 import { SearchUserDto } from '../../dto/search/search-filters.dto';
 import { DeleteUserUseCase } from '../../../core/use-cases/user/delete-user.use-case';
+import { UpdateUserProfileUseCase } from '../../../core/use-cases/user/update-user-profile.use-case';
+import { UpdateUserProfileDTO } from '../../dto/user/request/update-user-profile.dto';
+import { UserUpdateProfileDTO } from '../../dto/user/response/user-update-profile.dto';
 
 @UseGuards(JwtAuthGuard, UserExistGuad)
 @ApiTags('users')
@@ -33,7 +37,8 @@ export class UserController {
   constructor(
     private readonly userCreateProfileUseCase: UserCreateProfileUseCase,
     private readonly getAllUsersUseCase: GetAllUsersUseCase,
-    private readonly deleteUserUseCase: DeleteUserUseCase
+    private readonly deleteUserUseCase: DeleteUserUseCase,
+    private readonly updateUserUseCase: UpdateUserProfileUseCase
   ) {}
 
   @Post('profile')
@@ -90,6 +95,22 @@ export class UserController {
       };
     } catch (error) {
       throw new HttpException(error.message, HttpStatus.NOT_FOUND);
+    }
+  }
+  @Put('')
+  @ApiOperation({ summary: 'Actualizar el perfil del usuario' })
+  @ApiBody({ type: UpdateUserProfileDTO })
+  @ApiCreatedResponse({
+    description: 'Perfil del usuario actualizado',
+    type: UserUpdateProfileDTO
+  })
+  async updateUser(@Req() req: Request, @Body() userData: UpdateUserProfileDTO) {
+    try {
+      const user = req.user as { sub: string };
+      const updateUser = await this.updateUserUseCase.execute(user.sub, userData);
+      return plainToInstance(UserUpdateProfileDTO, updateUser);
+    } catch (error) {
+      throw new HttpException(error.message, HttpStatus.INTERNAL_SERVER_ERROR);
     }
   }
 }

--- a/src/interfaces/dto/card/request/create-card.dto.ts
+++ b/src/interfaces/dto/card/request/create-card.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+export class CreateCardDTO {
+  @ApiProperty({ example: 'Mariscos' })
+  @IsNotEmpty()
+  @IsString()
+  name: string;
+
+  @ApiProperty({ example: 'Descripcion de la carta...' })
+  @IsOptional()
+  @IsString()
+  description?: string;
+}

--- a/src/interfaces/dto/card/response/card-created.dto.ts
+++ b/src/interfaces/dto/card/response/card-created.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose } from 'class-transformer';
+
+export class CardCreatedDTO {
+  @ApiProperty({ example: 1 })
+  @Expose()
+  id: number;
+
+  @ApiProperty({ example: 'Bebidas' })
+  @Expose()
+  name: string;
+
+  @ApiProperty({ example: 'Descripcion de la carta ...' })
+  @Expose()
+  description?: string;
+
+  @ApiProperty({ example: true })
+  @Expose()
+  isActive: boolean;
+}

--- a/src/interfaces/dto/pagination/request/pagination-query-param.dto.ts
+++ b/src/interfaces/dto/pagination/request/pagination-query-param.dto.ts
@@ -1,0 +1,19 @@
+import { Transform, Type } from 'class-transformer';
+import { IsNumber, IsOptional, Max, Min } from 'class-validator';
+
+export class PaginationQueryParamDTO {
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  @Type(() => Number)
+  @Transform(({ value }) => parseInt(value) || 1)
+  page?: number = 1;
+
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  @Max(100)
+  @Type(() => Number)
+  @Transform(({ value }) => parseInt(value) || 10)
+  limit?: number = 10;
+}

--- a/src/interfaces/dto/pagination/response/pagination-data.dto.ts
+++ b/src/interfaces/dto/pagination/response/pagination-data.dto.ts
@@ -1,0 +1,18 @@
+import { Expose } from 'class-transformer';
+
+export class PaginationDataDTO {
+  @Expose()
+  total: number;
+
+  @Expose()
+  currentPage: number;
+
+  @Expose()
+  lastPage: number;
+
+  @Expose()
+  nextPage: number;
+
+  @Expose()
+  perPage: number;
+}

--- a/src/interfaces/dto/pagination/response/pagination-data.dto.ts
+++ b/src/interfaces/dto/pagination/response/pagination-data.dto.ts
@@ -1,18 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { Expose } from 'class-transformer';
 
 export class PaginationDataDTO {
+  @ApiProperty({ example: 10 })
   @Expose()
   total: number;
 
+  @ApiProperty({ example: 1 })
   @Expose()
   currentPage: number;
 
+  @ApiProperty({ example: 9 })
   @Expose()
   lastPage: number;
 
+  @ApiProperty({ example: 3 })
   @Expose()
   nextPage: number;
 
+  @ApiProperty({ example: 10 })
   @Expose()
   perPage: number;
 }

--- a/src/interfaces/dto/restaurant/response/restaurant.dto.ts
+++ b/src/interfaces/dto/restaurant/response/restaurant.dto.ts
@@ -2,7 +2,11 @@ import { ApiProperty } from '@nestjs/swagger';
 import { Expose, Type } from 'class-transformer';
 import { OpeningHourDTO } from '../../opening-hour/response/opening-hour.dto';
 
-export class RestaurantDTO {
+export class RestaurantResponseDTO {
+  @ApiProperty({ example: 1 })
+  @Expose()
+  id?: number;
+
   @ApiProperty({ example: 'Mi Restaurante Saludable' })
   @Expose()
   name: string;

--- a/src/interfaces/dto/search/search-filters.dto.ts
+++ b/src/interfaces/dto/search/search-filters.dto.ts
@@ -15,9 +15,12 @@ export class SearchUserDto {
   @ApiPropertyOptional({
     description: 'Relaciones a cargar. Puede ser un array simple o un objeto anidado',
     example: {
-      restaurant: ['id', 'name', 'address'],
-      admin: ['isDeleted'],
-      consumer: ['userName', 'isDeleted']
+      object: {
+        restaurant: ['id', 'name', 'address'],
+        admin: ['isDeleted'],
+        consumer: ['userName', 'isDeleted']
+      },
+      array: ['consumer', 'restaurant', 'admin']
     }
   })
   @IsOptional()

--- a/src/interfaces/dto/search/search-filters.dto.ts
+++ b/src/interfaces/dto/search/search-filters.dto.ts
@@ -1,14 +1,37 @@
-import { IsArray, IsObject, IsOptional, IsString } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsArray, IsString, IsObject } from 'class-validator';
 
 export class SearchUserDto {
+  @ApiPropertyOptional({
+    description: 'Campos específicos a seleccionar de la entidad',
+    example: ['id', 'name', 'email'],
+    type: [String]
+  })
   @IsOptional()
   @IsArray()
   @IsString({ each: true })
   select?: string[];
 
+  @ApiPropertyOptional({
+    description: 'Relaciones a cargar. Puede ser un array simple o un objeto anidado',
+    example: {
+      restaurant: ['id', 'name', 'address'],
+      admin: ['isDeleted'],
+      consumer: ['userName', 'isDeleted']
+    }
+  })
   @IsOptional()
   relations?: string[] | Record<string, string[] | boolean>;
 
+  @ApiPropertyOptional({
+    description: 'Filtros de búsqueda',
+    example: {
+      name: { op: 'like', value: 'John' },
+      age: { op: 'gte', value: 18 },
+      active: true
+    },
+    type: Object
+  })
   @IsOptional()
   @IsObject()
   where?: Record<
@@ -16,6 +39,11 @@ export class SearchUserDto {
     string | number | boolean | { op: 'eq' | 'like' | 'gte' | 'lte'; value: string | number | boolean }
   >;
 
+  @ApiPropertyOptional({
+    description: 'Orden de los resultados',
+    example: { createdAt: 'DESC' },
+    type: Object
+  })
   @IsOptional()
   @IsObject()
   order?: Record<string, 'ASC' | 'DESC'>;

--- a/src/interfaces/dto/search/search-filters.dto.ts
+++ b/src/interfaces/dto/search/search-filters.dto.ts
@@ -1,0 +1,22 @@
+import { IsArray, IsObject, IsOptional, IsString } from 'class-validator';
+
+export class SearchUserDto {
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  select?: string[];
+
+  @IsOptional()
+  relations?: string[] | Record<string, string[] | boolean>;
+
+  @IsOptional()
+  @IsObject()
+  where?: Record<
+    string,
+    string | number | boolean | { op: 'eq' | 'like' | 'gte' | 'lte'; value: string | number | boolean }
+  >;
+
+  @IsOptional()
+  @IsObject()
+  order?: Record<string, 'ASC' | 'DESC'>;
+}

--- a/src/interfaces/dto/user/request/update-user-profile.dto.ts
+++ b/src/interfaces/dto/user/request/update-user-profile.dto.ts
@@ -1,0 +1,58 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { CreateRestaurantDto } from '../../restaurant/request/create-restaurant.dto';
+import { IsNotEmpty, IsOptional, IsString, Length, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+
+class ConsumerDTO {
+  @ApiProperty({ example: 'Luis Fernando' })
+  @IsString()
+  userName: string;
+}
+
+export class UpdateUserProfileDTO {
+  @ApiProperty({ example: '123456789' })
+  @IsString()
+  @Length(9, 9)
+  @IsNotEmpty({ message: 'El phone es requerido' })
+  phone: string;
+
+  @ApiProperty({ example: 'Los Olivos' })
+  @IsString()
+  @IsNotEmpty({ message: 'El disctrict es requerido' })
+  district: string;
+
+  @ApiProperty({ example: 'Lima' })
+  @IsString()
+  @IsNotEmpty({ message: 'El province es requerido' })
+  province: string;
+
+  @ApiProperty({ example: 'Descripcion del usuario ...', required: false })
+  @IsString()
+  @IsOptional()
+  description?: string;
+
+  @ApiProperty({ example: 'https://example.com/avatar.png', required: false })
+  @IsOptional()
+  @IsString()
+  profilePicture?: string;
+
+  @ApiProperty({
+    type: () => CreateRestaurantDto,
+    required: false,
+    description: 'Información del restaurante (solo si el rol es "restaurant")'
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => CreateRestaurantDto)
+  restaurant?: CreateRestaurantDto;
+
+  @ApiProperty({
+    type: () => ConsumerDTO,
+    required: false,
+    description: 'Información del consumidor (solo si el rol es "restaurant")'
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => ConsumerDTO)
+  consumer?: ConsumerDTO;
+}

--- a/src/interfaces/dto/user/response/pagination-users.dto.ts
+++ b/src/interfaces/dto/user/response/pagination-users.dto.ts
@@ -1,0 +1,13 @@
+import { Expose, Type } from 'class-transformer';
+import { PaginationDataDTO } from '../../pagination/response/pagination-data.dto';
+import { UserResponseDto } from './user.dto';
+
+export class PaginationResponseUsers {
+  @Expose()
+  @Type(() => UserResponseDto)
+  data: UserResponseDto[];
+
+  @Expose()
+  @Type(() => PaginationDataDTO)
+  paginationData: PaginationDataDTO;
+}

--- a/src/interfaces/dto/user/response/pagination-users.dto.ts
+++ b/src/interfaces/dto/user/response/pagination-users.dto.ts
@@ -1,12 +1,15 @@
 import { Expose, Type } from 'class-transformer';
 import { PaginationDataDTO } from '../../pagination/response/pagination-data.dto';
 import { UserResponseDto } from './user.dto';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class PaginationResponseUsers {
+  @ApiProperty({ type: [UserResponseDto] })
   @Expose()
   @Type(() => UserResponseDto)
   data: UserResponseDto[];
 
+  @ApiProperty({ type: [PaginationDataDTO] })
   @Expose()
   @Type(() => PaginationDataDTO)
   paginationData: PaginationDataDTO;

--- a/src/interfaces/dto/user/response/user-profile.dto.ts
+++ b/src/interfaces/dto/user/response/user-profile.dto.ts
@@ -2,14 +2,17 @@ import { ApiProperty } from '@nestjs/swagger';
 import { Expose, Type } from 'class-transformer';
 import { RestaurantResponseDTO } from '../../restaurant/response/restaurant.dto';
 export class AdminResponseDTO {
+  @ApiProperty({ example: false })
   @Expose()
   isDeleted?: boolean;
 }
 
 export class ConsumerResponseDTO {
+  @ApiProperty({ example: 'Luis' })
   @Expose()
   userName: string;
 
+  @ApiProperty({ example: false })
   @Expose()
   isDeleted?: boolean;
 }
@@ -51,14 +54,17 @@ export class UserRegisterProfileDTO {
   @Expose()
   profilePicture?: string;
 
+  @ApiProperty({ type: [AdminResponseDTO] })
   @Expose()
   @Type(() => AdminResponseDTO)
   admin?: AdminResponseDTO;
 
+  @ApiProperty({ type: [ConsumerResponseDTO] })
   @Expose()
   @Type(() => ConsumerResponseDTO)
   consumer?: ConsumerResponseDTO;
 
+  @ApiProperty({ type: [RestaurantResponseDTO] })
   @Expose()
   @Type(() => RestaurantResponseDTO)
   restaurant?: RestaurantResponseDTO;

--- a/src/interfaces/dto/user/response/user-profile.dto.ts
+++ b/src/interfaces/dto/user/response/user-profile.dto.ts
@@ -1,9 +1,9 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Expose, Type } from 'class-transformer';
-import { RestaurantDTO } from '../../restaurant/response/restaurant.dto';
+import { RestaurantResponseDTO } from '../../restaurant/response/restaurant.dto';
 export class AdminResponseDTO {
   @Expose()
-  isDeleted: boolean;
+  isDeleted?: boolean;
 }
 
 export class ConsumerResponseDTO {
@@ -11,7 +11,7 @@ export class ConsumerResponseDTO {
   userName: string;
 
   @Expose()
-  isDeleted: boolean;
+  isDeleted?: boolean;
 }
 
 export class UserRegisterProfileDTO {
@@ -60,6 +60,6 @@ export class UserRegisterProfileDTO {
   consumer?: ConsumerResponseDTO;
 
   @Expose()
-  @Type(() => RestaurantDTO)
-  restaurant?: RestaurantDTO;
+  @Type(() => RestaurantResponseDTO)
+  restaurant?: RestaurantResponseDTO;
 }

--- a/src/interfaces/dto/user/response/user-update-profile.dto.ts
+++ b/src/interfaces/dto/user/response/user-update-profile.dto.ts
@@ -1,0 +1,41 @@
+import { Expose, Type } from 'class-transformer';
+import { RestaurantResponseDTO } from '../../restaurant/response/restaurant.dto';
+import { AdminResponseDTO, ConsumerResponseDTO } from './user-profile.dto';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UserUpdateProfileDTO {
+  @ApiProperty({ example: '12344456789' })
+  @Expose()
+  phone: string;
+
+  @ApiProperty({ example: 'Los Olivos' })
+  @Expose()
+  district: string;
+
+  @ApiProperty({ example: 'Lima' })
+  @Expose()
+  province: string;
+
+  @ApiProperty({ example: 'Descripcion del usuario ...' })
+  @Expose()
+  description?: string;
+
+  @ApiProperty({ example: 'https://example.com/avatar.png' })
+  @Expose()
+  profilePicture?: string;
+
+  @ApiProperty({ type: [RestaurantResponseDTO] })
+  @Expose()
+  @Type(() => RestaurantResponseDTO)
+  restaurant?: RestaurantResponseDTO;
+
+  @ApiProperty({ type: [ConsumerResponseDTO] })
+  @Expose()
+  @Type(() => ConsumerResponseDTO)
+  consumer?: ConsumerResponseDTO;
+
+  @ApiProperty({ type: [AdminResponseDTO] })
+  @Expose()
+  @Type(() => AdminResponseDTO)
+  admin?: AdminResponseDTO;
+}

--- a/src/interfaces/dto/user/response/user.dto.ts
+++ b/src/interfaces/dto/user/response/user.dto.ts
@@ -1,0 +1,62 @@
+import { Expose, Type } from 'class-transformer';
+import { RestaurantResponseDTO } from '../../restaurant/response/restaurant.dto';
+import { AdminResponseDTO, ConsumerResponseDTO } from './user-profile.dto';
+
+export class UserResponseDto {
+  @Expose()
+  id: number;
+
+  @Expose()
+  username: string;
+
+  @Expose()
+  sub: string;
+
+  @Expose()
+  emailVerified: boolean;
+
+  @Expose()
+  providerId: string;
+
+  @Expose()
+  dni: string;
+
+  @Expose()
+  firstName: string;
+
+  @Expose()
+  lastName: string;
+
+  @Expose()
+  phone: string;
+
+  @Expose()
+  email: string;
+
+  @Expose()
+  profilePicture?: string;
+
+  @Expose()
+  district: string;
+
+  @Expose()
+  province: string;
+
+  @Expose()
+  role: 'admin' | 'consumer' | 'restaurant';
+
+  @Expose()
+  description?: string;
+
+  @Expose()
+  @Type(() => RestaurantResponseDTO)
+  restaurant?: RestaurantResponseDTO;
+
+  @Expose()
+  @Type(() => AdminResponseDTO)
+  admin?: AdminResponseDTO;
+
+  @Expose()
+  @Type(() => ConsumerResponseDTO)
+  consumer?: ConsumerResponseDTO;
+}

--- a/src/interfaces/dto/user/response/user.dto.ts
+++ b/src/interfaces/dto/user/response/user.dto.ts
@@ -1,50 +1,66 @@
 import { Expose, Type } from 'class-transformer';
 import { RestaurantResponseDTO } from '../../restaurant/response/restaurant.dto';
 import { AdminResponseDTO, ConsumerResponseDTO } from './user-profile.dto';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class UserResponseDto {
+  @ApiProperty({ example: 1 })
   @Expose()
   id: number;
 
+  @ApiProperty({ example: 'Luis Fernando' })
   @Expose()
   username: string;
 
+  @ApiProperty({ example: '12nbb1io2o' })
   @Expose()
   sub: string;
 
+  @ApiProperty({ example: true })
   @Expose()
   emailVerified: boolean;
 
+  @ApiProperty({ example: 'google.com' })
   @Expose()
   providerId: string;
 
+  @ApiProperty({ example: '12345678' })
   @Expose()
   dni: string;
 
+  @ApiProperty({ example: 'Luis' })
   @Expose()
   firstName: string;
 
+  @ApiProperty({ example: 'Ventocilla' })
   @Expose()
   lastName: string;
 
+  @ApiProperty({ example: '123456789' })
   @Expose()
   phone: string;
 
+  @ApiProperty({ example: 'email@gmail.com' })
   @Expose()
   email: string;
 
+  @ApiProperty({ example: 'https://example.com/avatar.png' })
   @Expose()
   profilePicture?: string;
 
+  @ApiProperty({ example: 'Los Olivos' })
   @Expose()
   district: string;
 
+  @ApiProperty({ example: 'Lima' })
   @Expose()
   province: string;
 
+  @ApiProperty({ example: 'admin', enum: ['admin', 'consumer', 'restaurant'] })
   @Expose()
   role: 'admin' | 'consumer' | 'restaurant';
 
+  @ApiProperty({ example: 'Descripcion del usuario ...', required: false })
   @Expose()
   description?: string;
 


### PR DESCRIPTION
## 📋 Descripción

Este PR implementa la funcionalidad de **creación de cartas asociadas a un restaurante** mediante el envío del `restaurantId` como **Path Param**.  
De esta forma, cada carta queda correctamente vinculada al restaurante correspondiente, garantizando la integridad de la relación entre entidades.  

## ✨ Cambios incluidos  

- Nuevo endpoint **`POST /api/v1/restaurants/{restaurantId}/cards`** para registrar cartas.  
- Validación de la existencia del restaurante antes de permitir la creación.  
- Estructura clara de request con campos obligatorios y opcionales.  
- Respuestas consistentes para casos exitosos y de error.  
- Documentación en Swagger actualizada con ejemplos de uso.  

## 📥 Datos de entrada  

- **Path Param**:  
  - `restaurantId` → Identificador único del restaurante.  

- **Body**:  
  - `title` → Título o nombre de la carta.  
  - `description` → Breve descripción de la carta.  
  - `isActive` → Estado de la carta (activa o inactiva).  

## ✅ Checklist  

- [x] Endpoint creado y probado en entorno local.  
- [x] Validaciones implementadas.  
- [x] Swagger actualizado.  
- [x] Tests unitarios y de integración añadidos (si aplica).  

<img width="601" height="606" alt="image" src="https://github.com/user-attachments/assets/22f57123-6f2e-4d42-88c9-efbac8c4a321" />
<img width="608" height="483" alt="image" src="https://github.com/user-attachments/assets/96ca2251-43ff-4f3e-97b2-5d9663abf4ce" />

## 🚦 Checklist de calidad

- [x] Probado localmente
- [x] Cumple arquitectura (**Clean/Hexagonal**)
- [x] Documentación actualizada _(si aplica)_
- [x] Swagger/OpenAPI actualizado _(si aplica)_
- [x] `CHANGELOG.md` actualizado _(si aplica)_
- [x] Pasa `lint`, `format`, `test`
- [x] Rama actualizada con `develop`
- [x] Revisores asignados
